### PR TITLE
Create generic markdown table

### DIFF
--- a/src/kubernetes/deployment.ts
+++ b/src/kubernetes/deployment.ts
@@ -1,0 +1,20 @@
+import { V1Deployment } from '@kubernetes/client-node';
+import { KubernetesObjectKinds, ResultMetadata } from './kubernetesTypes';
+
+/**
+ * Deployment info object.
+ */
+export type Deployment = Required<V1Deployment> & {
+	readonly kind: KubernetesObjectKinds.Deployment;
+};
+
+/**
+ * Deployment results from running
+ * `get deployment` command.
+ */
+export interface DeploymentResult {
+	readonly apiVersion: string;
+	readonly kind: 'List';
+	readonly items: Deployment[];
+	readonly metadata: ResultMetadata;
+}

--- a/src/kubernetes/kubernetesTools.ts
+++ b/src/kubernetes/kubernetesTools.ts
@@ -1,15 +1,15 @@
-import { window, Uri } from 'vscode';
+import { Uri, window } from 'vscode';
 import * as kubernetes from 'vscode-kubernetes-tools-api';
-import { V1DeploymentList as DeploymentList } from '@kubernetes/client-node';
-import { setContext, ContextTypes } from '../context';
-import { KubernetesConfig } from './kubernetesConfig';
-import { KubernetesFileSchemes } from './kubernetesFileSchemes';
+import { ContextTypes, setContext } from '../context';
+import { parseJson } from '../utils/jsonUtils';
 import { BucketResult } from './bucket';
+import { DeploymentResult } from './deployment';
 import { GitRepositoryResult } from './gitRepository';
 import { HelmReleaseResult } from './helmRelease';
 import { HelmRepositoryResult } from './helmRepository';
+import { KubernetesConfig } from './kubernetesConfig';
+import { KubernetesFileSchemes } from './kubernetesFileSchemes';
 import { KustomizeResult } from './kustomize';
-import { parseJson } from '../utils/jsonUtils';
 
 
 /**
@@ -168,7 +168,7 @@ class KubernetesTools {
 	/**
 	 * Get all flux system deployments.
 	 */
-	async getFluxDeployments(): Promise<undefined | DeploymentList> {
+	async getFluxDeployments(): Promise<undefined | DeploymentResult> {
 		const fluxDeploymentShellResult = await this.invokeKubectlCommand('get deployment --namespace=flux-system -o json');
 		if (!fluxDeploymentShellResult || fluxDeploymentShellResult.stderr) {
 			console.warn(`Failed to get flux system deployments: ${fluxDeploymentShellResult?.stderr}`);

--- a/src/kubernetes/kubernetesTypes.ts
+++ b/src/kubernetes/kubernetesTypes.ts
@@ -18,7 +18,9 @@ export enum KubernetesObjectKinds {
 	Bucket = 'Bucket',
 	GitRepository = 'GitRepository',
 	HelmRepository = 'HelmRepository',
-	HelmRelease = 'HelmRelease'
+	HelmRelease = 'HelmRelease',
+	Kustomization = 'Kustomization',
+	Deployment = 'Deployment',
 }
 
 /**

--- a/src/kubernetes/kustomize.ts
+++ b/src/kubernetes/kustomize.ts
@@ -4,7 +4,8 @@ import {
 	LocalObjectReference,
 	KubernetesObject,
 	ObjectMeta,
-	ResultMetadata
+	ResultMetadata,
+	KubernetesObjectKinds
 } from './kubernetesTypes';
 
 /**
@@ -27,7 +28,7 @@ export interface Kustomize extends KubernetesObject {
 
 	// standard kubernetes object fields
 	readonly apiVersion: string;
-	readonly kind: 'Kustomization'
+	readonly kind: KubernetesObjectKinds.Kustomization;
 	readonly metadata: ObjectMeta;
 
 	/**

--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -1,3 +1,13 @@
+import { MarkdownString } from 'vscode';
+import { Bucket } from '../kubernetes/bucket';
+import { Deployment } from '../kubernetes/deployment';
+import { GitRepository } from '../kubernetes/gitRepository';
+import { HelmRelease } from '../kubernetes/helmRelease';
+import { HelmRepository } from '../kubernetes/helmRepository';
+import { Cluster } from '../kubernetes/kubernetesConfig';
+import { KubernetesObjectKinds } from '../kubernetes/kubernetesTypes';
+import { Kustomize } from '../kubernetes/kustomize';
+
 /**
  * Shortens revision string for display in GitOps tree views.
  * @param revision Revision string to shorten.
@@ -12,4 +22,92 @@ export function shortenRevision(revision: string = ''): string {
 	else {
 		return revision.slice(0, 7);
 	}
+}
+
+/**
+ * Create markdown table for tree view item hovers.
+ * 2 clumns, left aligned.
+ * @param kubernetesObject Standard kubernetes object
+ * @returns vscode MarkdownString object
+ */
+export function createMarkdownTable(kubernetesObject: Cluster | Bucket | GitRepository | HelmRepository | HelmRelease | Kustomize | Deployment): MarkdownString {
+	const markdown = new MarkdownString();
+	// Create table header
+	markdown.appendMarkdown('Property | Value\n');
+	markdown.appendMarkdown(':--- | :---\n');
+
+	// Cluster type is incompatible with the rest. Handle it first.
+	if ('cluster' in kubernetesObject) {
+		createMarkdownTableRow('name', kubernetesObject.name, markdown);
+		createMarkdownTableRow('server', kubernetesObject.cluster.server, markdown);
+		createMarkdownTableRow('certificate-authority', kubernetesObject.cluster['certificate-authority'], markdown);
+		createMarkdownTableRow('certificate-authority-data', kubernetesObject.cluster['certificate-authority-data'], markdown);
+		return markdown;
+	}
+
+	// Should exist on every object
+	createMarkdownTableRow('apiVersion', kubernetesObject.apiVersion, markdown);
+	createMarkdownTableRow('kind', kubernetesObject.kind, markdown);
+	createMarkdownTableRow('name', kubernetesObject.metadata?.name, markdown);
+	createMarkdownTableRow('namespace', kubernetesObject.metadata?.namespace, markdown);
+
+	// Should exist on multiple objects
+	if ('interval' in kubernetesObject.spec) {
+		createMarkdownTableRow('interval', kubernetesObject.spec.interval, markdown);
+	}
+	if ('timeout' in kubernetesObject.spec) {
+		createMarkdownTableRow('timeout', kubernetesObject.spec.timeout, markdown);
+	}
+
+	// Object-specific properties
+	if (kubernetesObject.kind === KubernetesObjectKinds.GitRepository) {
+		createMarkdownTableRow('url', kubernetesObject.spec?.url, markdown);
+		createMarkdownTableRow('branch', kubernetesObject.spec.ref?.branch, markdown);
+		createMarkdownTableRow('commit', kubernetesObject.spec.ref?.commit, markdown);
+	} else if (kubernetesObject.kind === KubernetesObjectKinds.HelmRepository) {
+		createMarkdownTableRow('url', kubernetesObject.spec?.url, markdown);
+	} else if (kubernetesObject.kind === KubernetesObjectKinds.Bucket) {
+		createMarkdownTableRow('name', kubernetesObject.spec.bucketName, markdown);
+		createMarkdownTableRow('endpoint', kubernetesObject.spec.endpoint, markdown);
+		createMarkdownTableRow('provider', kubernetesObject.spec.provider, markdown);
+		createMarkdownTableRow('insecure', kubernetesObject.spec.insecure, markdown);
+	} else if (kubernetesObject.kind === KubernetesObjectKinds.Kustomization) {
+		createMarkdownTableRow('prune', kubernetesObject.spec.prune, markdown);
+		createMarkdownTableRow('sourceRef.kind', kubernetesObject.spec.sourceRef.kind, markdown);
+		createMarkdownTableRow('sourceRef.name', kubernetesObject.spec.sourceRef.name, markdown);
+		createMarkdownTableRow('force', kubernetesObject.spec.force, markdown);
+		createMarkdownTableRow('path', kubernetesObject.spec.path, markdown);
+	} else if (kubernetesObject.kind === KubernetesObjectKinds.HelmRelease) {
+		createMarkdownTableRow('chart', kubernetesObject.spec.chart.spec.chart, markdown);
+		createMarkdownTableRow('chart.sourceRef.kind', kubernetesObject.spec.chart.spec.sourceRef.kind, markdown);
+		createMarkdownTableRow('chart.sourceRef.name', kubernetesObject.spec.chart.spec.sourceRef.name, markdown);
+		createMarkdownTableRow('chart.version', kubernetesObject.spec.chart.spec.version, markdown);
+	} else if (kubernetesObject.kind === KubernetesObjectKinds.Deployment) {
+		createMarkdownTableRow('spec.paused', kubernetesObject.spec.paused, markdown);
+		createMarkdownTableRow('spec.minReadySeconds', kubernetesObject.spec.minReadySeconds, markdown);
+		createMarkdownTableRow('spec.progressDeadlineSeconds', kubernetesObject.spec.progressDeadlineSeconds, markdown);
+	}
+
+	// Only show the first 10 lines (2 lines - header)
+	const markdownAsLines = markdown.value.split('\n');
+	if (markdownAsLines.length > 12) {
+		markdown.value = markdownAsLines
+			.slice(0, 12)
+			.join('\n');
+	}
+
+	return markdown;
+}
+
+/**
+ * Create markdown table row (only if the value is not equal `undefined`)
+ * @param propertyName First table column value
+ * @param propertyValue Second table column value
+ * @param markdown object of vscode type MarkdownString
+ */
+function createMarkdownTableRow(propertyName: string, propertyValue: string | boolean | number | undefined, markdown: MarkdownString) {
+	if (propertyValue === undefined) {
+		return;
+	}
+	markdown.appendMarkdown(`${propertyName} | ${propertyValue}\n`);
 }

--- a/src/views/clusterDeploymentTreeViewItem.ts
+++ b/src/views/clusterDeploymentTreeViewItem.ts
@@ -1,11 +1,12 @@
 import { MarkdownString } from 'vscode';
 import { EditorCommands } from '../commands';
 import { FileTypes } from '../fileTypes';
+import { Deployment } from '../kubernetes/deployment';
 import { kubernetesTools } from '../kubernetes/kubernetesTools';
 import { ResourceTypes } from '../kubernetes/kubernetesTypes';
+import { createMarkdownTable } from '../utils/stringUtils';
 import { TreeViewItem } from './treeViewItem';
 import { TreeViewItemContext } from './treeViewItemContext';
-import { V1Deployment as Deployment } from '@kubernetes/client-node';
 
 /**
  * Defines deployment tree view item for display in GitOps Clusters tree view.
@@ -41,11 +42,17 @@ export class ClusterDeploymentTreeViewItem extends TreeViewItem {
 	/**
 	 * Creates markdown string for Deployment tree view item tooltip.
 	 * @param deployment controller object.
+	 * @param showJsonConfig Optional show Json config flag for dev debug.
 	 * @returns Markdown string to use for Deployment tree view item tooltip.
 	 */
-	getMarkdown(deployment: Deployment): MarkdownString {
-		const markdown: MarkdownString = new MarkdownString();
-		// markdown.appendCodeblock(JSON.stringify(deployment, null, '  '));
+	getMarkdown(deployment: Deployment, showJsonConfig: boolean = false): MarkdownString {
+
+		const markdown: MarkdownString = createMarkdownTable(deployment);
+
+		if (showJsonConfig) {
+			markdown.appendCodeblock(JSON.stringify(deployment, null, '  '));
+		}
+
 		return markdown;
 	}
 }

--- a/src/views/clusterTreeViewDataProvider.ts
+++ b/src/views/clusterTreeViewDataProvider.ts
@@ -12,6 +12,7 @@ import { TreeViewItem } from './treeViewItem';
 import { TreeViewItemContext } from './treeViewItemContext';
 import { ClusterDeploymentTreeViewItem } from './clusterDeploymentTreeViewItem';
 import { statusBar } from '../statusBar';
+import { createMarkdownTable } from '../utils/stringUtils';
 
 
 /**
@@ -100,19 +101,8 @@ export class ClusterTreeViewItem extends TreeViewItem {
 	 * @returns Markdown string to use for Cluster tree view item tooltip.
 	 */
 	getMarkdown(cluster: Cluster,	showJsonConfig: boolean = false): MarkdownString {
-		const markdown: MarkdownString = new MarkdownString();
-		markdown.appendMarkdown('Property | Value\n');
-		markdown.appendMarkdown(':--- | :---\n');
-		markdown.appendMarkdown(`Name | ${cluster.name}\n`);
-		markdown.appendMarkdown(`Server | ${cluster.cluster.server}\n`);
 
-		if (cluster.cluster['certificate-authority']) {
-			markdown.appendMarkdown(`Certificate authority | ${cluster.cluster['certificate-authority']}`);
-		}
-
-		if (cluster.cluster['certificate-authority-data']) {
-			markdown.appendMarkdown(`Certificate authority data | ${cluster.cluster['certificate-authority-data']}`);
-		}
+		const markdown: MarkdownString = createMarkdownTable(cluster);
 
 		if (showJsonConfig) {
 			markdown.appendCodeblock(JSON.stringify(cluster, null, '  '), 'json');

--- a/src/views/deploymentTreeViewItem.ts
+++ b/src/views/deploymentTreeViewItem.ts
@@ -1,6 +1,7 @@
 import { MarkdownString } from 'vscode';
 import { HelmRelease } from '../kubernetes/helmRelease';
 import { Kustomize } from '../kubernetes/kustomize';
+import { createMarkdownTable } from '../utils/stringUtils';
 import { TreeViewItem } from './treeViewItem';
 
 /**
@@ -8,8 +9,6 @@ import { TreeViewItem } from './treeViewItem';
  */
 export class DeploymentTreeViewItem extends TreeViewItem {
 
-	// TODO: refactor this to pluck object properties we want to include in markdown tooltips
-	// and handle it genericallly for all tree view items in new ./utils/stringUtils.ts helper module
 	/**
 	 * Creates markdwon string for Deployment tree view item tooltip.
 	 * @param deployment Kustomize or HelmRelease deployment object.
@@ -19,46 +18,7 @@ export class DeploymentTreeViewItem extends TreeViewItem {
 	getMarkdown(deployment: Kustomize | HelmRelease,
 		showJsonConfig: boolean = false): MarkdownString {
 
-		const markdown: MarkdownString = new MarkdownString();
-		markdown.appendMarkdown(`Property | Value\n`);
-		markdown.appendMarkdown(`:--- | :---\n`);
-		markdown.appendMarkdown(`Api version | ${deployment.apiVersion}\n`);
-		markdown.appendMarkdown(`Kind | ${deployment.kind}\n`);
-
-		if (deployment.metadata.name) {
-			markdown.appendMarkdown(`Name | ${deployment.metadata.name}\n`);
-		}
-
-		if (deployment.metadata.namespace) {
-			markdown.appendMarkdown(`Namespace | ${deployment.metadata.namespace}\n`);
-		}
-
-		markdown.appendMarkdown(`Interval | ${deployment.spec.interval}\n`);
-		if (deployment.spec.timeout) {
-			markdown.appendMarkdown(`Timeout | ${deployment.spec.timeout}\n`);
-		}
-
-		if (deployment.kind === 'Kustomization') {
-			markdown.appendMarkdown(`Prune | ${deployment.spec.prune}\n`);
-			markdown.appendMarkdown(`Source ref kind | ${deployment.spec.sourceRef.kind}\n`);
-			markdown.appendMarkdown(`Source ref name | ${deployment.spec.sourceRef.name}\n`);
-
-			if (deployment.spec.force !== undefined) {
-				markdown.appendMarkdown(`Force | ${deployment.spec.force}\n`);
-			}
-
-			if (deployment.spec.path) {
-				markdown.appendMarkdown(`Path | ${deployment.spec.path}\n`);
-			}
-		}
-		else if (deployment.kind === 'HelmRelease') {
-			markdown.appendMarkdown(`Chart name | ${deployment.spec.chart.spec.chart}\n`);
-			markdown.appendMarkdown(`Chart source ref kind | ${deployment.spec.chart.spec.sourceRef.kind}\n`);
-			markdown.appendMarkdown(`Chart source ref name | ${deployment.spec.chart.spec.sourceRef.name}\n`);
-			if (deployment.spec.chart.spec.version) {
-				markdown.appendMarkdown(`Chart version | ${deployment.spec.chart.spec.version}\n`);
-			}
-		}
+		const markdown: MarkdownString = createMarkdownTable(deployment);
 
 		if (showJsonConfig) {
 			markdown.appendCodeblock(JSON.stringify(deployment, null, '  '), 'json');

--- a/src/views/sourceTreeViewItem.ts
+++ b/src/views/sourceTreeViewItem.ts
@@ -2,6 +2,7 @@ import { MarkdownString } from 'vscode';
 import { Bucket } from '../kubernetes/bucket';
 import { GitRepository } from '../kubernetes/gitRepository';
 import { HelmRepository } from '../kubernetes/helmRepository';
+import { createMarkdownTable } from '../utils/stringUtils';
 import { TreeViewItem } from './treeViewItem';
 
 /**
@@ -9,8 +10,6 @@ import { TreeViewItem } from './treeViewItem';
  */
  export class SourceTreeViewItem extends TreeViewItem {
 
-	// TODO: refactor this to pluck object properties we want to include in markdown tooltips
-	// and handle it genericallly for all tree view items in new ./utils/stringUtils.ts helper module
 	/**
 	 * Creates markdwon string for Source tree view item tooltip.
 	 * @param source GitRepository, HelmRepository or Bucket kubernetes object.
@@ -20,50 +19,7 @@ import { TreeViewItem } from './treeViewItem';
 	 getMarkdown(source: GitRepository | HelmRepository | Bucket,
 		showJsonConfig: boolean = false): MarkdownString {
 
-		const markdown: MarkdownString = new MarkdownString();
-		markdown.appendMarkdown(`Property | Value\n`);
-		markdown.appendMarkdown(`:--- | :---\n`);
-		markdown.appendMarkdown(`Api version | ${source.apiVersion}\n`);
-		markdown.appendMarkdown(`Kind | ${source.kind}\n`);
-
-		if (source.metadata.name) {
-			markdown.appendMarkdown(`Name | ${source.metadata.name}\n`);
-		}
-
-		if (source.metadata.namespace) {
-			markdown.appendMarkdown(`Namespace | ${source.metadata.namespace}\n`);
-		}
-
-		markdown.appendMarkdown(`Interval | ${source.spec.interval}\n`);
-		if (source.spec.timeout) {
-			markdown.appendMarkdown(`Timeout | ${source.spec.timeout}\n`);
-		}
-
-		if (source.kind === 'GitRepository') {
-			markdown.appendMarkdown(`URL | ${source.spec.url}\n`);
-			if (source.spec.ref) {
-				if (source.spec.ref.branch) {
-					markdown.appendMarkdown(`Branch | ${source.spec.ref.branch}\n`);
-				}
-
-				if (source.spec.ref.commit) {
-					markdown.appendMarkdown(`Commit | ${source.spec.ref.commit}\n`);
-				}
-			}
-		}
-		else if (source.kind === 'HelmRepository') {
-			markdown.appendMarkdown(`URL | ${source.spec.url}\n`);
-		}
-		else if (source.kind === 'Bucket') {
-			markdown.appendMarkdown(`Name | ${source.spec.bucketName}\n`);
-			markdown.appendMarkdown(`Endpoint | ${source.spec.endpoint}\n`);
-			if (source.spec.provider) {
-				markdown.appendMarkdown(`Provider | ${source.spec.provider}\n`);
-			}
-			if (source.spec.insecure !== undefined) {
-				markdown.appendMarkdown(`Insecure | ${source.spec.insecure}\n`);
-			}
-		}
+		const markdown: MarkdownString = createMarkdownTable(source);
 
 		if (showJsonConfig) {
 			markdown.appendCodeblock(JSON.stringify(source, null, '  '), 'json');


### PR DESCRIPTION
I have started with a generic function that accepted an object of type `any`, but that's not a good approach (no autocomplete defeats the purpose of using TypeScript).

This function accepts known objects and adding a new one is relatively easy (such as adding a deployment for cluster tree view, which was added with this PR).

I think properties that are shown should be chosen by someone who understands which are the important ones and sorted with higher importance being on top.

Trying to show whatever properties exist would be no better than a `.json` codeblock, only with even lower usefulness.