### PR TITLE
Change references from Wego to Weave GitOps

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ We recommend you install these CLI tools on your system PATH before using GitOps
 - Create Kustomization from opened in vscode folder
 - Preview short Kubernetes Object info in rich markdown table tooltips on hover for the loaded Clusters, Sources, and Workloads
 - Load Kubernetes Object manifest `.yaml` configs in vscode editor via [Kubernetes Tools API](https://github.com/Azure/vscode-kubernetes-tools-api) and virtual Kubernetes file system provider
-- Open [GitOps](https://www.weave.works/technologies/gitops/) Documentation links to [Flux](https://fluxcd.io/) and [Wego](https://www.weave.works/product/gitops-core/) CLI top level topics in your default web browser
+- Open [GitOps](https://www.weave.works/technologies/gitops/) Documentation links to [Flux](https://fluxcd.io/) and [Weave GitOps](https://www.weave.works/product/gitops-core/) CLI top level topics in your default web browser
 
 # GitOps Commands
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"kubernetes",
 		"flux",
 		"helm",
-		"wego",
+		"Weave GitOps",
 		"Azure",
 		"Arc",
 		"AKS",

--- a/src/views/documentationConfig.ts
+++ b/src/views/documentationConfig.ts
@@ -88,7 +88,7 @@ export const documentationLinks: DocumentationLink[] = [
 		],
 	},
 	{
-		title: 'Wego',
+		title: 'Weave GitOps',
 		url: 'https://docs.gitops.weave.works',
 		icon: 'resources/icons/gitops-logo.png',
 		links: [


### PR DESCRIPTION
Wego isn't generally recognised, better to use the product name. 

Untested due to simple nature of the change. 