### PR TITLE
Remove go-fish

### DIFF
--- a/src/commands/installFluxCli.ts
+++ b/src/commands/installFluxCli.ts
@@ -144,16 +144,6 @@ export async function installFluxCli() {
 		return;
 	}
 
-	// Use system package manager if possible https://gofi.sh
-	const goFishInstalledResult = await isGoFishInstalled();
-	if (succeeded(goFishInstalledResult)) {
-		const installFluxResult = await shell.execWithOutput('gofish install flux');
-		if (installFluxResult.code === 0) {
-			showNotificationToReloadTheEditor();
-		}
-		return;
-	}
-
 	if (platform === Platform.Windows) {
 		const latestFluxVersionResult = await getLatestVersionFromGitHub(fluxGitHubUserProject);
 		if (failed(latestFluxVersionResult)) {
@@ -282,21 +272,6 @@ export async function installFluxCli() {
 			}
 		},
 	);
-}
-
-async function isGoFishInstalled(): Promise<Errorable<null>> {
-	const gofishVersionShellResult = await shell.exec('gofish version');
-	if (gofishVersionShellResult.code === 0) {
-		return {
-			succeeded: true,
-			result: null,
-		};
-	} else {
-		return {
-			succeeded: false,
-			error: [shellCodeError(gofishVersionShellResult)],
-		};
-	}
 }
 
 async function showNotificationToReloadTheEditor() {


### PR DESCRIPTION
Ref: https://github.com/fluxcd/website/pull/852

The infrastructure has been archived at https://github.com/fishworks/gofish – if this option is used, then it will result in out-of-date Flux binaries – I'm removing gofish from my dotfiles now, it's unlikely that it gets picked up and adopted IMHO.

It was a nice idea, the automation is really good! It's frankly a lot lighter weight than brew but it has the same problem as `helm/charts` did – someone needs to own and maintain it.

There is a question whether we should install the binary at all, or just use the preferred package manager when it's available – in this case the brew tap at `fluxcd/tap/flux` is the preferred package manager for Flux.

This PR only removes go-fish for now.