### PR TITLE
globalState metadata is cluster only. refactor.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-gitops-tools",
-	"version": "0.19.2-pre1",
+	"version": "0.19.2-pre3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-gitops-tools",
-			"version": "0.19.2-pre1",
+			"version": "0.19.2-pre3",
 			"license": "MPL-2.0",
 			"dependencies": {
 				"@kubernetes/client-node": "^0.16.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-gitops-tools",
 	"displayName": "GitOps Tools",
 	"description": "GitOps automation tools for continuous delivery of Kubernetes and Cloud Native applications",
-	"version": "0.19.2-pre1",
+	"version": "0.19.2-pre3",
 	"publisher": "weaveworks",
 	"engines": {
 		"vscode": "^1.59.0",

--- a/src/azure/getAzureMetadata.ts
+++ b/src/azure/getAzureMetadata.ts
@@ -1,5 +1,6 @@
 import { window } from 'vscode';
 import { globalState } from '../extension';
+import { kubernetesTools } from '../kubernetes/kubernetesTools';
 
 export interface AzureMetadata {
 	resourceGroup: string;
@@ -15,7 +16,8 @@ export interface AzureMetadata {
  * @param contextName cluster name as in kubernetes config
  */
 export async function askUserForAzureMetadata(contextName: string): Promise<AzureMetadata | undefined> {
-	const azureMetadata = globalState.getClusterMetadata(contextName);
+	const clusterName = await kubernetesTools.getClusterName(contextName);
+	const azureMetadata = globalState.getClusterMetadata(clusterName);
 
 	const resourceGroup = await window.showInputBox({
 		title: 'Enter the Azure Resource Group (where the cluster is)',

--- a/src/commands/enableDisableGitOps.ts
+++ b/src/commands/enableDisableGitOps.ts
@@ -1,7 +1,7 @@
 import { window } from 'vscode';
 import { azureTools, isAzureProvider } from '../azure/azureTools';
 import { failed } from '../errorable';
-import { telemetry, globalState } from '../extension';
+import { telemetry } from '../extension';
 import { fluxTools } from '../flux/fluxTools';
 import { checkIfOpenedFolderGitRepositorySourceExists } from '../git/checkIfOpenedFolderGitRepositorySourceExists';
 import { kubernetesTools } from '../kubernetes/kubernetesTools';
@@ -31,8 +31,7 @@ async function enableDisableGitOps(clusterNode: ClusterContextNode | undefined, 
 		clusterName = currentClusterInfo.result.clusterName;
 	}
 
-	const clusterMetadata = globalState.getClusterMetadata(clusterName);
-	const clusterProvider = clusterMetadata?.clusterProvider || await kubernetesTools.detectClusterProvider(contextName);
+	const clusterProvider = await kubernetesTools.detectClusterProvider(contextName);
 
 	if (clusterProvider === ClusterProvider.Unknown) {
 		window.showErrorMessage('Cluster provider not detected yet.');

--- a/src/kubernetes/kubernetesTools.ts
+++ b/src/kubernetes/kubernetesTools.ts
@@ -3,7 +3,7 @@ import { Uri, window } from 'vscode';
 import * as kubernetes from 'vscode-kubernetes-tools-api';
 import { AzureConstants } from '../azure/azureTools';
 import { Errorable, failed, succeeded } from '../errorable';
-import { telemetry } from '../extension';
+import { globalState, telemetry } from '../extension';
 import { checkIfOpenedFolderGitRepositorySourceExists } from '../git/checkIfOpenedFolderGitRepositorySourceExists';
 import { output } from '../output';
 import { shellCodeError } from '../shell';
@@ -213,6 +213,16 @@ class KubernetesTools {
 		};
 	}
 
+	async getClusterName(contextName: string): Promise<string> {
+		const contexts = await this.getContexts();
+		if(contexts.succeeded === true) {
+			return contexts.result.find(context => context.name === contextName)?.context.clusterInfo?.name || contextName;
+		} else {
+			return contextName;
+		}
+	}
+
+
 	/**
 	 * Get pods by a deployment name.
 	 * @param name pod target name
@@ -421,11 +431,18 @@ class KubernetesTools {
 	}
 
 	/**
-	 * Try to detect known cluster providers.
+	 * Try to detect known cluster providers. Returns user selected cluster type if that is set.
 	 * @param context target context to get resources from.
 	 * TODO: maybe use Errorable?
 	 */
 	async detectClusterProvider(context: string): Promise<ClusterProvider> {
+		const clusterName = await kubernetesTools.getClusterName(context);
+		const clusterMetadata = globalState.getClusterMetadata(clusterName);
+
+		if(clusterMetadata?.clusterProvider) {
+			return clusterMetadata.clusterProvider;
+		}
+
 		const tryProviderAzureARC = await this.isClusterAzureARC(context);
 		if (tryProviderAzureARC === ClusterProvider.AzureARC) {
 			return ClusterProvider.AzureARC;

--- a/src/views/nodes/clusterContextNode.ts
+++ b/src/views/nodes/clusterContextNode.ts
@@ -69,7 +69,7 @@ export class ClusterContextNode extends TreeNode {
 
 		this.cluster = kubernetesContext.context.clusterInfo;
 		this.clusterContext = kubernetesContext;
-		this.clusterName = kubernetesContext.name;
+		this.clusterName = kubernetesContext.context.clusterInfo?.name || kubernetesContext.name;
 		this.contextName = kubernetesContext.name;
 		this.description = kubernetesContext.context.clusterInfo?.cluster.server;
 

--- a/src/views/treeViews.ts
+++ b/src/views/treeViews.ts
@@ -106,10 +106,7 @@ export interface CurrentClusterInfo {
  * 3. Detect cluster provider.
  */
 export async function getCurrentClusterInfo(): Promise<Errorable<CurrentClusterInfo>> {
-	const [currentContextResult, contextsResult] = await Promise.all([
-		kubernetesTools.getCurrentContext(),
-		kubernetesTools.getContexts(),
-	]);
+	const currentContextResult = await kubernetesTools.getCurrentContext();
 
 	if (failed(currentContextResult)) {
 		const error = `Failed to get current context ${currentContextResult.error[0]}`;
@@ -120,23 +117,9 @@ export async function getCurrentClusterInfo(): Promise<Errorable<CurrentClusterI
 		};
 	}
 	const currentContextName = currentContextResult.result;
-	if (failed(contextsResult)) {
-		const error = `Failed to get contexts ${contextsResult.error[0]}`;
-		window.showErrorMessage(error);
-		return {
-			succeeded: false,
-			error: [error],
-		};
-	}
 
-	const currentClusterName = contextsResult.result.find(context => context.name === currentContextName)?.context.clusterInfo?.name;
-	if (!currentClusterName) {
-		window.showErrorMessage('Failed to find current cluster name.');
-		return {
-			succeeded: false,
-			error: ['Failed to find current cluster name.'],
-		};
-	}
+
+	let currentClusterName = await kubernetesTools.getClusterName(currentContextName);
 
 	// Pick user cluster provider override if defined
 	const clusterMetadata = globalState.getClusterMetadata(currentClusterName);


### PR DESCRIPTION
Make sure only `clusterName` is used for the global metadata key. refactor `kubernetesTools.getClusterName`

Signed-off-by: Juozas G <juozasgaigalas@gmail.com>