### PR TITLE
parallel awaits for Sources in sourceDataProvider

### DIFF
--- a/src/views/dataProviders/sourceDataProvider.ts
+++ b/src/views/dataProviders/sourceDataProvider.ts
@@ -24,24 +24,28 @@ export class SourceDataProvider extends DataProvider {
 
 		setVSCodeContext(ContextTypes.LoadingSources, true);
 
-		// load git repositories for the current cluster
-		const gitRepositories = await kubernetesTools.getGitRepositories();
+		// Fetch all sources asynchronously and at once
+		const [gitRepositories, helmRepositories, buckets] = await Promise.all([
+			kubernetesTools.getGitRepositories(),
+			kubernetesTools.getHelmRepositories(),
+			kubernetesTools.getBuckets(),
+		]);
+
+		// add git repositories to the tree
 		if (gitRepositories) {
 			for (const gitRepository of gitRepositories.items) {
 				treeItems.push(new GitRepositoryNode(gitRepository));
 			}
 		}
 
-		// load helm repositores for the current cluster
-		const helmRepositories = await kubernetesTools.getHelmRepositories();
+		// add helm repositores to the tree
 		if (helmRepositories) {
 			for (const helmRepository of helmRepositories.items) {
 				treeItems.push(new HelmRepositoryNode(helmRepository));
 			}
 		}
 
-		// load buckets for the current cluster
-		const buckets = await kubernetesTools.getBuckets();
+		// add buckets to the tree
 		if (buckets) {
 			for (const bucket of buckets.items) {
 				treeItems.push(new BucketNode(bucket));


### PR DESCRIPTION
Do as in workloadsDataProvider – when there are multiple resource kinds to fetch, get them in parallel

This avoids an uncomfortably long wait for `Sources` tree view timing out compared with the Workloads tree view that times out in about 30s.

(Timeouts are not in our control for now, since the kubectl implementation comes from kubernetes provider extension, but we can control how many times we call operations in succession that might time out.)