### PR TITLE
Fix "GitOps Running: :"

### DIFF
--- a/src/shell.ts
+++ b/src/shell.ts
@@ -137,7 +137,7 @@ async function execWithOutput(
 		// Show vscode notification loading message
 		return window.withProgress({
 			location: ProgressLocation.Notification,
-			title: 'GitOps Running: ',
+			title: 'GitOps Running',
 		}, innerExec);
 	} else {
 		// No progress


### PR DESCRIPTION
There is a double colon in the output, don't need a colon here it seems