### PR TITLE
Fix bug querying too broadly HelmReleases

### DIFF
--- a/src/kubernetes/helmRelease.ts
+++ b/src/kubernetes/helmRelease.ts
@@ -3,7 +3,7 @@ import { DependsOn, KubeConfig, Kustomize, NamespacedObjectKindReference } from 
 
 /**
  * Helm releases result from running
- * `kubectl get HelmRelease -A` command.
+ * `kubectl get helmreleases.helm.toolkit.fluxcd.io -A` command.
  */
 export interface HelmReleaseResult {
 	readonly apiVersion: string;

--- a/src/kubernetes/kubernetesTools.ts
+++ b/src/kubernetes/kubernetesTools.ts
@@ -274,7 +274,7 @@ class KubernetesTools {
 	 * Gets all helm releases from the current kubectl context.
 	 */
 	async getHelmReleases(): Promise<undefined | HelmReleaseResult> {
-		const helmReleaseShellResult = await this.invokeKubectlCommand('get HelmRelease -A -o json');
+		const helmReleaseShellResult = await this.invokeKubectlCommand('get helmreleases.helm.toolkit.fluxcd.io -A -o json');
 		if (helmReleaseShellResult?.code !== 0) {
 			console.warn(`Failed to get kubectl helm releases: ${helmReleaseShellResult?.stderr}`);
 			if (helmReleaseShellResult?.stderr && !this.notAnErrorServerDoesntHaveResourceTypeRegExp.test(helmReleaseShellResult.stderr)) {


### PR DESCRIPTION
There is a bug on clusters where Flux v1 is installed, the wrong HelmReleases CRD might be called, since we have both:

`helmreleases.helm.fluxcd.io`
and
`helmreleases.helm.toolkit.fluxcd.io`

Let's be explicit so that Flux v1 users who are trying to upgrade get the best experience possible during the upgrading time.