### PR TITLE
Having prereleases automatically marked as such

### DIFF
--- a/.github/workflows/build-vsix.yml
+++ b/.github/workflows/build-vsix.yml
@@ -10,28 +10,28 @@ jobs:
     permissions:
       contents: write
     steps:
-    - uses: "actions/checkout@v2"
-    - uses: "actions/setup-node@v2"
-      with:
-        node-version: "16"
-    - name: Install dependencies
-      run: npm install
-    - run: npm run compile
-    - run: npm install -g vsce
-    - run: vsce package
+      - uses: "actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e" # pin@v2
+      - uses: "actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561" # pin@v2
+        with:
+          node-version: "16"
+      - name: Install dependencies
+        run: npm install
+      - run: npm run compile
+      - run: npm install -g vsce
+      - run: vsce package
 
-    - name: Get the version
-      id: version
-      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-      shell: bash
+      - name: Get the version
+        id: version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+        shell: bash
 
-    - uses: apexskier/github-semver-parse@v1
-      id: semver
-      with:
-        version: ${{ steps.version.outputs.VERSION }}
+      - uses: apexskier/github-semver-parse@671ddf80785e4d721e76723ec1e687317f85bfe9 # pin@v1
+        id: semver
+        with:
+          version: ${{ steps.version.outputs.VERSION }}
 
-    - uses: ncipollo/release-action@v1
-      with:
-        artifacts: "vscode-gitops-tools-*.vsix"
-        token: ${{ secrets.GITHUB_TOKEN }}
-        prerelease: ${{ !!steps.semver.outputs.prerelease }}
+      - uses: ncipollo/release-action@58ae73b360456532aafd58ee170c045abbeaee37 # pin@v1
+        with:
+          artifacts: "vscode-gitops-tools-*.vsix"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          prerelease: ${{ !!steps.semver.outputs.prerelease }}

--- a/.github/workflows/build-vsix.yml
+++ b/.github/workflows/build-vsix.yml
@@ -19,7 +19,19 @@ jobs:
     - run: npm run compile
     - run: npm install -g vsce
     - run: vsce package
+
+    - name: Get the version
+      id: version
+      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      shell: bash
+
+    - uses: apexskier/github-semver-parse@v1
+      id: semver
+      with:
+        version: ${{ steps.version.outputs.VERSION }}
+
     - uses: ncipollo/release-action@v1
       with:
         artifacts: "vscode-gitops-tools-*.vsix"
         token: ${{ secrets.GITHUB_TOKEN }}
+        prerelease: ${{ !!steps.semver.outputs.prerelease }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,19 +11,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
+      - uses: actions/setup-node@17f8bd926464a1afa4c6a11669539e9c1ba77048 # pin@v3
         with:
           node-version: '16'
       - run: npm install
       - name: Setup Kubernetes
-        uses: engineerd/setup-kind@v0.5.0
+        uses: engineerd/setup-kind@aa272fe2a7309878ffc2a81c56cfe3ef108ae7d0 # pin@v0.5.0
         with:
           version: v0.12.0
           image: kindest/node:v1.20.7
       - run: 'wget https://fluxcd.io/install.sh'
       - run: 'bash install.sh'
       - name: extension test
-        uses: GabrielBB/xvfb-action@v1
+        uses: GabrielBB/xvfb-action@86d97bde4a65fe9b290c0b3fb92c2c4ed0e5302d # pin@v1
         with:
           run: 'npm test'


### PR DESCRIPTION
It will be helpful to ensure that prerelease tags are automatically marked as prereleases by the release automation

According to semver, any version with a dash and some string after it, is a prerelease version with the dash suffix being the prerelease part.

I tested this as `0.20.0-alpha.6` and it worked 👍 the release was automatically generated and marked as a prerelease, so it would not go to the front page nor be published as a final release in any downstream who was not subscribed to prereleases.