### PR TITLE
Sort order

### DIFF
--- a/src/views/dataProviders/workloadDataProvider.ts
+++ b/src/views/dataProviders/workloadDataProvider.ts
@@ -45,13 +45,33 @@ export class WorkloadDataProvider extends DataProvider {
 		this.namespaceResult = namespaces;
 
 		if (kustomizations) {
-			for (const kustomizeWorkload of kustomizations.items) {
+			for (const kustomizeWorkload of kustomizations.items.sort((k1, k2) => {
+				if (k1.metadata.name && k2.metadata.name) {
+					if (k1.metadata.name > k2.metadata.name) {
+						return 1;
+					}
+					if (k1.metadata.name < k2.metadata.name) {
+						return -1;
+					}
+				}
+				return 0;
+			})) {
 				workloadNodes.push(new KustomizationNode(kustomizeWorkload));
 			}
 		}
 
 		if (helmReleases) {
-			for (const helmRelease of helmReleases.items) {
+			for (const helmRelease of helmReleases.items.sort((h1, h2) => {
+				if (h1.metadata.name && h2.metadata.name) {
+					if (h1.metadata.name > h2.metadata.name) {
+						return 1;
+					}
+					if (h1.metadata.name < h2.metadata.name) {
+						return -1;
+					}
+				}
+				return 0;
+			})) {
 				workloadNodes.push(new HelmReleaseNode(helmRelease));
 			}
 		}

--- a/src/views/dataProviders/workloadDataProvider.ts
+++ b/src/views/dataProviders/workloadDataProvider.ts
@@ -12,6 +12,8 @@ import { TreeNode } from '../nodes/treeNode';
 import { WorkloadNode } from '../nodes/workloadNode';
 import { refreshWorkloadsTreeView } from '../treeViews';
 import { DataProvider } from './dataProvider';
+import { HelmReleaseResult } from '../../kubernetes/helmRelease';
+import { KustomizeResult } from '../../kubernetes/kustomize';
 
 /**
  * Defines data provider for loading Kustomizations
@@ -45,33 +47,13 @@ export class WorkloadDataProvider extends DataProvider {
 		this.namespaceResult = namespaces;
 
 		if (kustomizations) {
-			for (const kustomizeWorkload of kustomizations.items.sort((k1, k2) => {
-				if (k1.metadata.name && k2.metadata.name) {
-					if (k1.metadata.name > k2.metadata.name) {
-						return 1;
-					}
-					if (k1.metadata.name < k2.metadata.name) {
-						return -1;
-					}
-				}
-				return 0;
-			})) {
+			for (const kustomizeWorkload of this.sortKsByMetadataName(kustomizations)) {
 				workloadNodes.push(new KustomizationNode(kustomizeWorkload));
 			}
 		}
 
 		if (helmReleases) {
-			for (const helmRelease of helmReleases.items.sort((h1, h2) => {
-				if (h1.metadata.name && h2.metadata.name) {
-					if (h1.metadata.name > h2.metadata.name) {
-						return 1;
-					}
-					if (h1.metadata.name < h2.metadata.name) {
-						return -1;
-					}
-				}
-				return 0;
-			})) {
+			for (const helmRelease of this.sortHrByMetadataName(helmReleases)) {
 				workloadNodes.push(new HelmReleaseNode(helmRelease));
 			}
 		}
@@ -85,6 +67,33 @@ export class WorkloadDataProvider extends DataProvider {
 		statusBar.stopLoadingTree();
 
 		return workloadNodes;
+	}
+
+	sortKsByMetadataName(kss: KustomizeResult): KustomizeResult['items'] {
+		return kss.items.sort((k1, k2) => {
+			if (k1.metadata.name && k2.metadata.name) {
+				if (k1.metadata.name > k2.metadata.name) {
+					return 1;
+				}
+				if (k1.metadata.name < k2.metadata.name) {
+					return -1;
+				}
+			}
+			return 0;
+		});
+	}
+	sortHrByMetadataName(hrr: HelmReleaseResult): HelmReleaseResult['items'] {
+		return hrr.items.sort((h1, h2) => {
+			if (h1.metadata.name && h2.metadata.name) {
+				if (h1.metadata.name > h2.metadata.name) {
+					return 1;
+				}
+				if (h1.metadata.name < h2.metadata.name) {
+					return -1;
+				}
+			}
+			return 0;
+		});
 	}
 
 	buildWorkloadsTree(node: TreeNode, resourceTree: FluxTreeResources[], parentNamespace = '') {


### PR DESCRIPTION
There are some attempts at adjusting the sort order here

I think that we should have a few more passes on the sorter. In this PR, I removed the sort by namespace which was jarring and unhelpful for me and sorted by name instead. I think we should also sort by status, like was added in this PR for Flux's monitoring guides with Grafana:

* https://github.com/fluxcd/flux2/pull/2727