### PR TITLE
Borrow release workflow from Stateful.com

### DIFF
--- a/.github/workflows/build-vsix.yml
+++ b/.github/workflows/build-vsix.yml
@@ -1,10 +1,4 @@
 name: Publish
-# ---
-# name: Build and Publish VSIX GitOps Extension Release
-# on:
-#   push:
-#     tags:
-#       - '**'
 
 on:
   workflow_dispatch:
@@ -88,6 +82,8 @@ jobs:
           node-version: 16
       - name: Install dependencies
         run: npm install
+      - name: Install vsce globally
+        run: npm install -g vsce
       - name: Build Package
         run: npm run compile
 

--- a/.github/workflows/build-vsix.yml
+++ b/.github/workflows/build-vsix.yml
@@ -38,7 +38,7 @@ on:
         description: "Publish on Open VSX Registry?"
         required: true
         type: choice
-        default: "yes"
+        default: "no"
         options:
           - "yes"
           - "no"

--- a/.github/workflows/build-vsix.yml
+++ b/.github/workflows/build-vsix.yml
@@ -37,37 +37,6 @@ on:
           - "yes"
           - "no"
 
-#   build:
-#     runs-on: ubuntu-latest
-#     permissions:
-#       contents: write
-#     steps:
-#       - uses: "actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e" # pin@v2
-#       - uses: "actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561" # pin@v2
-#         with:
-#           node-version: "16"
-#       - name: Install dependencies
-#         run: npm install
-#       - run: npm run compile
-#       - run: npm install -g vsce
-#       - run: vsce package
-# 
-#       - name: Get the version
-#         id: version
-#         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-#         shell: bash
-# 
-#       - uses: apexskier/github-semver-parse@671ddf80785e4d721e76723ec1e687317f85bfe9 # pin@v1
-#         id: semver
-#         with:
-#           version: ${{ steps.version.outputs.VERSION }}
-# 
-#       - uses: ncipollo/release-action@58ae73b360456532aafd58ee170c045abbeaee37 # pin@v1
-#         with:
-#           artifacts: "vscode-gitops-tools-*.vsix"
-#           token: ${{ secrets.GITHUB_TOKEN }}
-#           prerelease: ${{ !!steps.semver.outputs.prerelease }}
-
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -169,3 +138,19 @@ jobs:
           bodyFile: ${{ github.workspace }}-CHANGELOG.txt
           tag: ${{ env.GIT_TAG }}
           prerelease: ${{ github.event.inputs.releaseChannel == 'edge' }}
+
+#       - name: Get the version
+#         id: version
+#         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+#         shell: bash
+#
+#       - uses: apexskier/github-semver-parse@671ddf80785e4d721e76723ec1e687317f85bfe9 # pin@v1
+#         id: semver
+#         with:
+#           version: ${{ steps.version.outputs.VERSION }}
+#
+#       - uses: ncipollo/release-action@58ae73b360456532aafd58ee170c045abbeaee37 # pin@v1
+#         with:
+#           artifacts: "vscode-gitops-tools-*.vsix"
+#           token: ${{ secrets.GITHUB_TOKEN }}
+#           prerelease: ${{ !!steps.semver.outputs.prerelease }}

--- a/.github/workflows/build-vsix.yml
+++ b/.github/workflows/build-vsix.yml
@@ -1,37 +1,175 @@
----
-name: Build and Publish VSIX GitOps Extension Release
+name: Publish
+# ---
+# name: Build and Publish VSIX GitOps Extension Release
+# on:
+#   push:
+#     tags:
+#       - '**'
+
 on:
-  push:
-    tags:
-      - '**'
+  workflow_dispatch:
+    inputs:
+      releaseType:
+        description: "Release Type"
+        required: true
+        type: choice
+        default: "patch"
+        options:
+          - patch
+          - minor
+          - major
+      releaseChannel:
+        description: "Release Channel"
+        required: true
+        type: choice
+        default: stable
+        options:
+          - stable
+          - edge
+      publishMarketplace:
+        description: "Publish on Visual Studio Marketplace?"
+        required: true
+        type: choice
+        default: "yes"
+        options:
+          - "yes"
+          - "no"
+      publishOpenVSX:
+        description: "Publish on Open VSX Registry?"
+        required: true
+        type: choice
+        default: "yes"
+        options:
+          - "yes"
+          - "no"
+
+#   build:
+#     runs-on: ubuntu-latest
+#     permissions:
+#       contents: write
+#     steps:
+#       - uses: "actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e" # pin@v2
+#       - uses: "actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561" # pin@v2
+#         with:
+#           node-version: "16"
+#       - name: Install dependencies
+#         run: npm install
+#       - run: npm run compile
+#       - run: npm install -g vsce
+#       - run: vsce package
+# 
+#       - name: Get the version
+#         id: version
+#         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+#         shell: bash
+# 
+#       - uses: apexskier/github-semver-parse@671ddf80785e4d721e76723ec1e687317f85bfe9 # pin@v1
+#         id: semver
+#         with:
+#           version: ${{ steps.version.outputs.VERSION }}
+# 
+#       - uses: ncipollo/release-action@58ae73b360456532aafd58ee170c045abbeaee37 # pin@v1
+#         with:
+#           artifacts: "vscode-gitops-tools-*.vsix"
+#           token: ${{ secrets.GITHUB_TOKEN }}
+#           prerelease: ${{ !!steps.semver.outputs.prerelease }}
+
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
-      - uses: "actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e" # pin@v2
-      - uses: "actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561" # pin@v2
+      - name: Clone Repository
+        uses: actions/checkout@v2
         with:
-          node-version: "16"
+          fetch-depth: 0
+      - name: Setup Node version
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
       - name: Install dependencies
         run: npm install
-      - run: npm run compile
-      - run: npm install -g vsce
-      - run: vsce package
+      - name: Build Package
+        run: npm run compile
 
-      - name: Get the version
-        id: version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-        shell: bash
-
-      - uses: apexskier/github-semver-parse@671ddf80785e4d721e76723ec1e687317f85bfe9 # pin@v1
-        id: semver
+      - name: Run Tests
+        uses: GabrielBB/xvfb-action@v1
         with:
-          version: ${{ steps.version.outputs.VERSION }}
+          run: npm test
+          options: "-screen 0 1600x1200x24"
 
-      - uses: ncipollo/release-action@58ae73b360456532aafd58ee170c045abbeaee37 # pin@v1
+      - name: Create Changelog
+        run: |
+          git log $(git describe --tags --abbrev=0)..HEAD --oneline &> ${{ github.workspace }}-CHANGELOG.txt
+          cat ${{ github.workspace }}-CHANGELOG.txt
+      - name: Setup Git
+        run: |
+          git config --global user.name "gitops-release-bot"
+          git config --global user.email "kingdon+github-bot@weave.works"
+      - name: Get Current Version Number
+        run: |
+          CURRENT_VERSION=$(cat package.json | jq .version | cut -d'"' -f 2)
+          echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
+      - name: Compile New Version (Edge)
+        run: |
+          RELEASE_VERSION=$(npx semver $CURRENT_VERSION -i pre${{ github.event.inputs.releaseType }} --preid edge)
+          echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
+          echo "Bump to $RELEASE_VERSION"
+        if: ${{ github.event.inputs.releaseChannel == 'edge' && !contains(env.CURRENT_VERSION, 'edge') }}
+      - name: Compile New Version (Edge)
+        run: |
+          RELEASE_VERSION=$(npx semver $CURRENT_VERSION -i prerelease)
+          echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
+          echo "Bump to $RELEASE_VERSION"
+        if: ${{ github.event.inputs.releaseChannel == 'edge' && contains(env.CURRENT_VERSION, 'edge') }}
+      - name: Compile New Version (Stable)
+        run: |
+          RELEASE_VERSION=$(npx semver $CURRENT_VERSION -i github.event.inputs.releaseType)
+          echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
+          echo "Bump to $RELEASE_VERSION"
+        if: ${{ github.event.inputs.releaseChannel == 'stable' }}
+      - name: Version Package
+        run: |
+          npm version $RELEASE_VERSION
+          git tag -a $RELEASE_VERSION -m "$RELEASE_VERSION"
+      - name: Package Extension (Edge)
+        if: ${{ github.event.inputs.releaseChannel == 'edge' }}
+        run: |
+          node .github/scripts/updateEdgeVersion.js
+          vsce package --pre-release --no-git-tag-version --no-update-package-json -o "./gitops-tools-$RELEASE_VERSION.vsix" ${{ github.event.inputs.additionalFlags }}
+      - name: Package Extension (Stable)
+        run: vsce package $RELEASE_VERSION --no-git-tag-version --no-update-package-json -o "./gitops-tools-$RELEASE_VERSION.vsix" ${{ github.event.inputs.additionalFlags }}
+        if: ${{ github.event.inputs.releaseChannel == 'stable' }}
+      - name: Publish to Visual Studio Marketplace (Edge)
+        run: vsce publish --packagePath "./gitops-tools-$RELEASE_VERSION.vsix" --pre-release --no-git-tag-version --no-update-package-json -p ${{ secrets.VSC_MKTP_PAT }} ${{ github.event.inputs.additionalFlags }}
+        if: ${{ github.event.inputs.publishMarketplace == 'yes' && github.event.inputs.releaseChannel == 'edge' }}
+      - name: Publish to Visual Studio Marketplace (Stable)
+        run: vsce publish --packagePath "./gitops-tools-$RELEASE_VERSION.vsix" --no-git-tag-version --no-update-package-json -p ${{ secrets.VSC_MKTP_PAT }} ${{ github.event.inputs.additionalFlags }}
+        if: ${{ github.event.inputs.publishMarketplace == 'yes' && github.event.inputs.releaseChannel == 'stable' }}
+      - name: Publish to Open VSX Registry (Edge)
+        uses: HaaLeo/publish-vscode-extension@v1
+        if: ${{ github.event.inputs.publishOpenVSX == 'yes' && github.event.inputs.releaseChannel == 'edge' }}
         with:
-          artifacts: "vscode-gitops-tools-*.vsix"
-          token: ${{ secrets.GITHUB_TOKEN }}
-          prerelease: ${{ !!steps.semver.outputs.prerelease }}
+          preRelease: true
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}
+          extensionFile: ./gitops-tools-${{ env.RELEASE_VERSION }}.vsix
+      - name: Publish to Open VSX Registry (Stable)
+        uses: HaaLeo/publish-vscode-extension@v1
+        if: ${{ github.event.inputs.publishOpenVSX == 'yes' && github.event.inputs.releaseChannel == 'stable' }}
+        with:
+          preRelease: false
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}
+          extensionFile: ./gitops-tools-${{ env.RELEASE_VERSION }}.vsix
+      - name: Push Tags
+        run: |
+          git log -1 --stat
+          git push origin main --tags
+      - run: |
+          export GIT_TAG=$(git describe --tags --abbrev=0)
+          echo "GIT_TAG=$GIT_TAG" >> $GITHUB_ENV
+      - name: GitHub Release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "./gitops-tools-*"
+          bodyFile: ${{ github.workspace }}-CHANGELOG.txt
+          tag: ${{ env.GIT_TAG }}
+          prerelease: ${{ github.event.inputs.releaseChannel == 'edge' }}

--- a/.github/workflows/build-vsix.yml
+++ b/.github/workflows/build-vsix.yml
@@ -123,7 +123,7 @@ jobs:
         if: ${{ github.event.inputs.releaseChannel == 'edge' && contains(env.CURRENT_VERSION, 'edge') }}
       - name: Compile New Version (Stable)
         run: |
-          RELEASE_VERSION=$(npx semver $CURRENT_VERSION -i github.event.inputs.releaseType)
+          RELEASE_VERSION=$(npx semver $CURRENT_VERSION -i ${{ github.event.inputs.releaseType }})
           echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
           echo "Bump to $RELEASE_VERSION"
         if: ${{ github.event.inputs.releaseChannel == 'stable' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,4 @@ jobs:
         uses: GabrielBB/xvfb-action@86d97bde4a65fe9b290c0b3fb92c2c4ed0e5302d # pin@v1
         with:
           run: 'npm test'
+          options: "-screen 0 1600x1200x24"


### PR DESCRIPTION
From a release engineering perspective, this is what is changing for the releaser:

You need no longer: `git tag` and `git push` when it's time to do a release. The release workflow is triggered via workflow dispatch (eg. manually, with a simple form). The release workflow includes a series of input panels where submitter can select whether it is a "prerelease" for the edge channel, or not (stable), and which distributions should be published.

The release **executes the CI test** as part of the release workflow process and if the CI test fails, the release will abort and no tag will be pushed. The tag is generated on successful CI run only.

If the release workflow succeeds, a new SemVer release tag is calculated using `npx semver` with an increment based on your selection "patch", "minor", "major" and a commit updates the package manifests with the updated version number.

It is also possible to select the `edge` channel which pushes a prerelease build, and honors the versioning semantic required by VSCode which does not participate in prerelease semantic versioning yet.

Folks can opt into the pre-releases on their installation page and they are easy to find when searching in the marketplace (easy to find at least when there is a prerelease newer than the latest stable release.)