### PR TITLE
Upgrade vscode engine to support pre-release versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
 			},
 			"engines": {
 				"npm": ">=7.0.0",
-				"vscode": "^1.59.0"
+				"vscode": "^1.63.0"
 			}
 		},
 		"node_modules/@discoveryjs/json-ext": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"version": "0.19.2",
 	"publisher": "weaveworks",
 	"engines": {
-		"vscode": "^1.59.0",
+		"vscode": "^1.63.0",
 		"npm": ">=7.0.0"
 	},
 	"categories": [


### PR DESCRIPTION
pre-release versions are not supported until `engine >=1.63` according to the error message here:
https://github.com/weaveworks/vscode-gitops-tools/runs/6787070035?check_suite_focus=true#step:18:592

So let's upgrade to that version