### PR TITLE
Workaround for the robot user not having Admin

### DIFF
--- a/.github/workflows/build-vsix.yml
+++ b/.github/workflows/build-vsix.yml
@@ -134,7 +134,7 @@ jobs:
       - name: Push Tags
         run: |
           git log -1 --stat
-          git push origin main --tags
+          git push origin main:release-pr --tags
       - run: |
           export GIT_TAG=$(git describe --tags --abbrev=0)
           echo "GIT_TAG=$GIT_TAG" >> $GITHUB_ENV
@@ -145,6 +145,18 @@ jobs:
           bodyFile: ${{ github.workspace }}-CHANGELOG.txt
           tag: ${{ env.GIT_TAG }}
           prerelease: ${{ github.event.inputs.releaseChannel == 'edge' }}
+
+          # We need to use a pull request because we don't want to make an exception for
+          # our main branch "no push without a pull request" even for some robot. So just merge this PR.
+      - uses: repo-sync/pull-request@v2
+        name: pull-request
+        if: ${{ github.event.inputs.releaseChannel == 'edge' }}
+        with:
+          destination_branch: "main"
+          pr_title: "Release ${{ env.GIT_TAG }}"
+          pr_body: "A release has been tagged as ${{ env.GIT_TAG }}. Merge this PR to main to complete it."
+          pr_reviewer: "kingdonb"
+          pr_draft: false
 
 #       - name: Get the version
 #         id: version


### PR DESCRIPTION
We could grant the robot user admin access to the repo and let it bypass the protected main branch. I don't have time for that now, I would have to go through terraform and it is easier to just make the release process raise a PR.

This should work. 👍 