### PR TITLE
Set the GITHUB_TOKEN environment variable

### DIFF
--- a/.github/workflows/build-vsix.yml
+++ b/.github/workflows/build-vsix.yml
@@ -157,6 +157,7 @@ jobs:
           pr_body: "A release has been tagged as ${{ env.GIT_TAG }}. Merge this PR to main to complete it."
           pr_reviewer: "kingdonb"
           pr_draft: false
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
 #       - name: Get the version
 #         id: version


### PR DESCRIPTION
This is from the example here:

https://fluxcd.io/docs/use-cases/gh-actions-auto-pr/

It was missing GITHUB_TOKEN and errored out again at the last minute:

https://github.com/weaveworks/vscode-gitops-tools/runs/6787353380?check_suite_focus=true#step:28:14