### PR TITLE
Fix release metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-gitops-tools",
-	"version": "0.19.2",
+	"version": "0.19.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-gitops-tools",
-			"version": "0.19.2",
+			"version": "0.19.3",
 			"license": "MPL-2.0",
 			"dependencies": {
 				"@kubernetes/client-node": "^0.16.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-gitops-tools",
 	"displayName": "GitOps Tools",
 	"description": "GitOps automation tools for continuous delivery of Kubernetes and Cloud Native applications",
-	"version": "0.19.2",
+	"version": "0.19.3",
 	"publisher": "weaveworks",
 	"engines": {
 		"vscode": "^1.63.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,16 @@
 	"displayName": "GitOps Tools",
 	"description": "GitOps automation tools for continuous delivery of Kubernetes and Cloud Native applications",
 	"version": "0.19.3",
+	"author": "Kingdon Barrett <kingdon@weave.works>",
+	"contributors": [
+		"Kingdon Barrett <kingdon@weave.works>",
+		"Juozas Gaigalas <juozasgaigalas@gmail.com>",
+		"Alexander <usernamehw@gmail.com>",
+		"Taras Novak <taras.novak@randomfractals.com>",
+		"Leonardo Murillo <leonardo@weave.works>"
+	],
 	"publisher": "weaveworks",
+	"icon": "resources/icons/gitops-logo.png",
 	"engines": {
 		"vscode": "^1.63.0",
 		"npm": ">=7.0.0"


### PR DESCRIPTION
I believe it's the missing icon from the metadata which caused the release to crash the search in Extension Marketplace (I had to delete 0.19.3 from the store permanently, and the edge release that preceded it.)

Fingers crossed that 0.19.4 treats us better! 🤞 