### PR TITLE
Add debugging helpers

### DIFF
--- a/.github/workflows/build-vsix.yml
+++ b/.github/workflows/build-vsix.yml
@@ -101,6 +101,8 @@ jobs:
         if: ${{ github.event.inputs.releaseChannel == 'stable' }}
       - name: Version Package
         run: |
+          git status
+          git diff && git diff --cached
           npm version $RELEASE_VERSION
           git tag -a $RELEASE_VERSION -m "$RELEASE_VERSION"
       - name: Package Extension (Edge)


### PR DESCRIPTION
The release workflow is failing because of some changes in the tree, it's not clear from the debug output what that diff is.

Adding some print statements to clarify the next attempt (now watch, it won't fail again... it just failed 7 times in a row.)