### PR TITLE
Try to raise our SEO profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![VSCode Marketplace Link](https://vsmarketplacebadge.apphb.com/version-short/weaveworks.vscode-gitops-tools.svg)
 ![Install Counter](https://vsmarketplacebadge.apphb.com/installs/weaveworks.vscode-gitops-tools.svg)
 
-Weaveworks GitOps Extension provides an intuitive way to manage, troubleshoot and operate your Kubernetes environment following the GitOps operating model, accelerating your development lifecycle and simplifying your continuous delivery pipelines.
+Weaveworks GitOps Extension provides an intuitive way to manage, troubleshoot and operate your Kubernetes environment following the GitOps operating model, accelerating your development lifecycle and simplifying your continuous delivery pipelines. The extension is built on Flux; to learn more about the GitOps toolkit, visit [FluxCD.io]
 
 Your feedback is very important to us, please help us by [submitting issues](https://github.com/weaveworks/vscode-gitops-tools/issues) for bugs, enhancements and share with us how you are using the extension.
 
@@ -126,3 +126,5 @@ Install from `.vsix` file step is only required for testing the latest version o
 # Data and telemetry
 
 The GitOps Tools Extension for Visual Studio Code collects usage data and sends it to Weaveworks to help improve our products and services. Read our [privacy statement](https://www.weave.works/weaveworks-privacy-policy/) to learn more. This extension respects the `telemetry.enableTelemetry` setting.
+
+[FluxCD.io]: https://fluxcd.io/

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Weaveworks GitOps Extension provides an intuitive way to manage, troubleshoot an
 
 Your feedback is very important to us, please help us by [submitting issues](https://github.com/weaveworks/vscode-gitops-tools/issues) for bugs, enhancements and share with us how you are using the extension.
 
-Weaveworks GitOps Extension integrates with [Kubernetes Tools](https://marketplace.visualstudio.com/items?itemName=ms-kubernetes-tools.vscode-kubernetes-tools), [`kubectl`](https://kubernetes.io/docs/reference/kubectl/overview/) and [`flux`](https://fluxcd.io/) for a consolidated and tightly integrated user experience.
+Weaveworks GitOps Extension integrates with [Kubernetes Tools](https://marketplace.visualstudio.com/items?itemName=ms-kubernetes-tools.vscode-kubernetes-tools), [`kubectl`](https://kubernetes.io/docs/reference/kubectl/overview/) and [`flux` (FluxCD)](https://fluxcd.io/) for a consolidated and tightly integrated user experience.
 
-> This extension is under active development and currently available as an alpha product.
+> This extension is under active development and is in a rolling beta release cycle with stable releases. Breaking changes remain a possibility.
 
 # Getting started
 


### PR DESCRIPTION
It is possible that we do not rank highly in the extension marketplace when searching for "Flux" because we hardly say Flux at all in the docs.

Also, there is no search result at all when searching for FluxCD. Hopefully we will be searchable as "FluxCD" after this change.