### PR TITLE
add fluxcd to keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"GitOps",
 		"kubernetes",
 		"flux",
+		"fluxcd",
 		"helm",
 		"Weave GitOps",
 		"Azure",


### PR DESCRIPTION
Related to #300

It should return the vscode extension in the marketplace when you type in "fluxcd" 👍 