### PR TITLE
(Edge Pre-release) Open webview document

### DIFF
--- a/.github/workflows/build-vsix.yml
+++ b/.github/workflows/build-vsix.yml
@@ -137,6 +137,12 @@ jobs:
         run: |
           git log -1 --stat
           git push origin --force-with-lease main:release-pr --tags
+        if: ${{ github.event.inputs.releaseChannel != 'edge' }}
+      - name: Push Tags (Edge)
+        run: |
+          git log -1 --stat
+          git push origin --tags
+        if: ${{ github.event.inputs.releaseChannel == 'edge' }}
       - run: |
           export GIT_TAG=$(git describe --tags --abbrev=0)
           echo "GIT_TAG=$GIT_TAG" >> $GITHUB_ENV

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
 				"@vscode/extension-telemetry": "^0.4.7",
 				"extract-zip": "^2.0.1",
 				"git-url-parse": "^11.6.0",
+				"node-fetch": "^3.2.4",
 				"semver": "^7.3.5",
 				"shelljs": "^0.8.5",
 				"vscode-kubernetes-tools-api": "^1.3.0"
@@ -1410,6 +1411,14 @@
 				"node": ">=0.10"
 			}
 		},
+		"node_modules/data-uri-to-buffer": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
+			"integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
 		"node_modules/debug": {
 			"version": "4.3.3",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
@@ -1958,6 +1967,28 @@
 				"pend": "~1.2.0"
 			}
 		},
+		"node_modules/fetch-blob": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.5.tgz",
+			"integrity": "sha512-N64ZpKqoLejlrwkIAnb9iLSA3Vx/kjgzpcDhygcqJ2KKjky8nCgUQ+dzXtbrLaWZGZNmNfQTsiQ0weZ1svglHg==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"dependencies": {
+				"node-domexception": "^1.0.0",
+				"web-streams-polyfill": "^3.0.3"
+			},
+			"engines": {
+				"node": "^12.20 || >= 14.13"
+			}
+		},
 		"node_modules/file-entry-cache": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -2053,6 +2084,17 @@
 			},
 			"engines": {
 				"node": ">= 0.12"
+			}
+		},
+		"node_modules/formdata-polyfill": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+			"dependencies": {
+				"fetch-blob": "^3.1.2"
+			},
+			"engines": {
+				"node": ">=12.20.0"
 			}
 		},
 		"node_modules/fs-minipass": {
@@ -3089,6 +3131,41 @@
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
 			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
 			"dev": true
+		},
+		"node_modules/node-domexception": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "github",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"engines": {
+				"node": ">=10.5.0"
+			}
+		},
+		"node_modules/node-fetch": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.4.tgz",
+			"integrity": "sha512-WvYJRN7mMyOLurFR2YpysQGuwYrJN+qrrpHjJDuKMcSPdfFccRUla/kng2mz6HWSBxJcqPbvatS6Gb4RhOzCJw==",
+			"dependencies": {
+				"data-uri-to-buffer": "^4.0.0",
+				"fetch-blob": "^3.1.4",
+				"formdata-polyfill": "^4.0.10"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/node-fetch"
+			}
 		},
 		"node_modules/node-releases": {
 			"version": "1.1.75",
@@ -4386,6 +4463,14 @@
 			},
 			"engines": {
 				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/web-streams-polyfill": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+			"integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+			"engines": {
+				"node": ">= 8"
 			}
 		},
 		"node_modules/webpack": {
@@ -5755,6 +5840,11 @@
 				"assert-plus": "^1.0.0"
 			}
 		},
+		"data-uri-to-buffer": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
+			"integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA=="
+		},
 		"debug": {
 			"version": "4.3.3",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
@@ -6167,6 +6257,15 @@
 				"pend": "~1.2.0"
 			}
 		},
+		"fetch-blob": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.5.tgz",
+			"integrity": "sha512-N64ZpKqoLejlrwkIAnb9iLSA3Vx/kjgzpcDhygcqJ2KKjky8nCgUQ+dzXtbrLaWZGZNmNfQTsiQ0weZ1svglHg==",
+			"requires": {
+				"node-domexception": "^1.0.0",
+				"web-streams-polyfill": "^3.0.3"
+			}
+		},
 		"file-entry-cache": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -6235,6 +6334,14 @@
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.6",
 				"mime-types": "^2.1.12"
+			}
+		},
+		"formdata-polyfill": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+			"requires": {
+				"fetch-blob": "^3.1.2"
 			}
 		},
 		"fs-minipass": {
@@ -7009,6 +7116,21 @@
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
 			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
 			"dev": true
+		},
+		"node-domexception": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
+		},
+		"node-fetch": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.4.tgz",
+			"integrity": "sha512-WvYJRN7mMyOLurFR2YpysQGuwYrJN+qrrpHjJDuKMcSPdfFccRUla/kng2mz6HWSBxJcqPbvatS6Gb4RhOzCJw==",
+			"requires": {
+				"data-uri-to-buffer": "^4.0.0",
+				"fetch-blob": "^3.1.4",
+				"formdata-polyfill": "^4.0.10"
+			}
 		},
 		"node-releases": {
 			"version": "1.1.75",
@@ -7950,6 +8072,11 @@
 				"glob-to-regexp": "^0.4.1",
 				"graceful-fs": "^4.1.2"
 			}
+		},
+		"web-streams-polyfill": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+			"integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q=="
 		},
 		"webpack": {
 			"version": "5.71.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-gitops-tools",
-	"version": "0.19.9",
+	"version": "0.19.10-edge.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-gitops-tools",
-			"version": "0.19.9",
+			"version": "0.19.10-edge.0",
 			"license": "MPL-2.0",
 			"dependencies": {
 				"@kubernetes/client-node": "^0.16.2",

--- a/package.json
+++ b/package.json
@@ -182,6 +182,11 @@
 				"category": "GitOps"
 			},
 			{
+				"command": "gitops.openWebviewDocumentURI",
+				"title": "Open Document in Editor Window",
+				"category": "GitOps"
+			},
+			{
 				"command": "gitops.createKustomization",
 				"title": "Create Kustomization",
 				"icon": "$(add)",
@@ -557,6 +562,7 @@
 		"@vscode/extension-telemetry": "^0.4.7",
 		"extract-zip": "^2.0.1",
 		"git-url-parse": "^11.6.0",
+		"node-fetch": "^3.2.4",
 		"semver": "^7.3.5",
 		"shelljs": "^0.8.5",
 		"vscode-kubernetes-tools-api": "^1.3.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-gitops-tools",
 	"displayName": "GitOps Tools",
 	"description": "GitOps automation tools for continuous delivery of Kubernetes and Cloud Native applications",
-	"version": "0.19.9",
+	"version": "0.19.10-edge.0",
 	"author": "Kingdon Barrett <kingdon@weave.works>",
 	"contributors": [
 		"Kingdon Barrett <kingdon@weave.works>",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -11,6 +11,7 @@ import { fluxReconcileSourceCommand } from './commands/fluxReconcileSource';
 import { fluxReconcileWorkload } from './commands/fluxReconcileWorkload';
 import { installFluxCli } from './commands/installFluxCli';
 import { openCreateSourceWebview } from './commands/openCreateSourceWebview';
+import { openWebviewDocumentURI } from './commands/openWebviewDocumentURI';
 import { openResource } from './commands/openResource';
 import { pullGitRepository } from './commands/pullGitRepository';
 import { resume } from './commands/resume';
@@ -77,6 +78,7 @@ export const enum CommandId {
 	// webview
 	ShowLogs = 'gitops.editor.showLogs',
 	OpenCreateSourceWebview = 'gitops.editor.createSource',
+	OpenWebviewDocumentURI = 'gitops.openWebviewDocumentURI',
 
 	// output commands
 	ShowOutputChannel = 'gitops.output.show',
@@ -132,6 +134,7 @@ export function registerCommands(context: ExtensionContext) {
 	// webview
 	registerCommand(CommandId.ShowLogs, showLogs);
 	registerCommand(CommandId.OpenCreateSourceWebview, openCreateSourceWebview);
+	registerCommand(CommandId.OpenWebviewDocumentURI, openWebviewDocumentURI);
 
 	// output
 	registerCommand(CommandId.ShowOutputChannel, showOutputChannel);

--- a/src/commands/openWebviewDocumentURI.ts
+++ b/src/commands/openWebviewDocumentURI.ts
@@ -12,10 +12,10 @@ export async function openWebviewDocumentURI(uri: Uri, title?: string) {
 
 	const panel = window.createWebviewPanel(
 		'gitopsWebview', // Identifies the type of the webview. Used internally
-		title || 'Documentation',
+		title || 'Documentation', // Fallback to this string if no title provided
 		ViewColumn.One, // Editor column to show the new webview panel in.
-		{ // Enable scripts in the webview
-			enableScripts: true, //Set this to true if you want to enable Javascript.
+		{
+			enableScripts: false, // (Note: scripts did not seem to be working when enabled)
 		},
 	);
 

--- a/src/commands/openWebviewDocumentURI.ts
+++ b/src/commands/openWebviewDocumentURI.ts
@@ -1,0 +1,27 @@
+import { Uri, window, ViewColumn, env } from 'vscode';
+import { failed } from '../errorable';
+import { telemetry } from '../extension';
+import fetch from 'node-fetch';
+
+/**
+ * Open the webview with some documentation from a URL.
+ */
+export async function openWebviewDocumentURI(uri: Uri, title?: string) {
+	// Based on example from:
+	// https://betterprogramming.pub/how-to-add-webviews-to-a-visual-studio-code-extension-69884706f056
+
+	const panel = window.createWebviewPanel(
+		'gitopsWebview', // Identifies the type of the webview. Used internally
+		title || 'Documentation',
+		ViewColumn.One, // Editor column to show the new webview panel in.
+		{ // Enable scripts in the webview
+			enableScripts: true, //Set this to true if you want to enable Javascript.
+		},
+	);
+
+	panel.webview.html = await getWebviewContent(uri);
+}
+
+async function getWebviewContent(uri: Uri) {
+	return await (await fetch(uri.toString())).text();
+}

--- a/src/views/documentationConfig.ts
+++ b/src/views/documentationConfig.ts
@@ -7,12 +7,19 @@ export interface DocumentationLink {
 	url: string;
 	icon?: string;
 	links?: DocumentationLink[];
+	webview?: boolean;
 }
 
 /**
  * links config for GitOps Documentation tree view.
  */
 export const documentationLinks: DocumentationLink[] = [
+	{
+		title: 'GitOps VSCode Docs',
+		url: 'https://github.com/weaveworks/vscode-gitops-tools',
+		icon: 'resources/icons/flux-logo.png',
+		webview: true,
+	},
 	{
 		title: 'Flux',
 		url: 'https://fluxcd.io/docs',

--- a/src/views/nodes/documentationNode.ts
+++ b/src/views/nodes/documentationNode.ts
@@ -13,11 +13,15 @@ export class DocumentationNode extends TreeNode {
 	 * Url of the external web page with documentation.
 	 */
 	url: string;
+	webview: boolean;
+	title: string;
 
 	constructor(link: DocumentationLink, isParent = false) {
 		super(link.title);
 
 		this.url = link.url;
+		this.webview = link.webview || false;
+		this.title = link.title;
 
 		if (link.icon) {
 			this.iconPath = asAbsolutePath(link.icon);
@@ -29,10 +33,18 @@ export class DocumentationNode extends TreeNode {
 	}
 
 	get command() {
-		return {
-			command: CommandId.VSCodeOpen,
-			arguments: [Uri.parse(this.url)],
-			title: 'Open link',
-		};
+		if(this.webview) {
+			return {
+				command: CommandId.OpenWebviewDocumentURI,
+				arguments: [Uri.parse(this.url), this.title],
+				title: 'Open document',
+			}
+		} else {
+			return {
+				command: CommandId.VSCodeOpen,
+				arguments: [Uri.parse(this.url)],
+				title: 'Open link',
+			};
+		}
 	}
 }


### PR DESCRIPTION
The prerelease channel has `0.19.10-edge.0` which is the first "edge channel" feature

Users can subscribe to the pre-release build channel for early access to features which may change through iteration, or even be cancelled before they are able to be made available in the next stable release.

It should be 0.19.11-edge* - I'll fix this for the next edge build, but it doesn't matter here because the patch number gets deleted and replaced with a timestamp anyway (details about that in a separate issue thread, I'll link back to this one)