### PR TITLE
Fix: use namespace for flux tree kustomization

### DIFF
--- a/src/views/dataProviders/workloadDataProvider.ts
+++ b/src/views/dataProviders/workloadDataProvider.ts
@@ -103,7 +103,7 @@ export class WorkloadDataProvider extends DataProvider {
 
 		let workloadChildren;
 		if (workloadNode instanceof KustomizationNode) {
-			const resourceTree = await fluxTools.tree(name, targetNamespace);
+			const resourceTree = await fluxTools.tree(name, namespace);
 
 			if (!resourceTree || !resourceTree.resources) {
 				workloadNode.children = [new TreeNode('No Resources')];


### PR DESCRIPTION
Fix #315

The targetNamespace is not the right thing to use in this place, except for HelmReleases. We should definitely find a way to cover this in test, but it looks like we already had split this function based on how it should work for HelmRelease vs Kustomization. I think this will work.