### PR TITLE
improve docs around prerelease workflow

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -33,14 +33,18 @@ Install from `.vsix` file step is only required for testing the latest version o
 
 In order to release a new version the extension, visit the Publish action from [build-vsix.yaml](https://github.com/weaveworks/vscode-gitops-tools/actions/workflows/build-vsix.yml) and run the workflow as a `workflow_dispatch` trigger.
 
-Set the parameters of Release Type (major, minor, patch) and use the Release Channel (stable).
+Choose a branch: `main` or `edge`, and set the parameters of Release Type (major, minor, patch) then use the Release Channel (stable) or (prerelease). Stable releases correspond to the `main` branch and prereleases should come from `edge`.
 
 Publish on Visual Studio Marketplace (yes), currently the Open VSX Registry is not supported.
 
 Add your entries to CHANGELOG before publishing the release (or after publishing, in the event that patches are being published frequently the CHANGELOG may be allowed to fall behind, but should be updated in the tree for MINOR releases.)
 
+The release process will update CHANGELOG and populate releases with a list of changes. This looks nicer if "Squash and Merge" is used.
+
 It is not necessary to increment the version number manually in package.json, the release workflow takes care of this.
 
-Upon success, the Publish workflow will have created a new GitHub release, pushed the tag, added the CHANGELOG, and submitted a PR with the updates to `package.json` and `package-lock.json`. It can be merged to complete the process.
+**Important:** Upon success, the Publish workflow will have created a new GitHub release, pushed the tag, added the CHANGELOG, and submitted a PR from the branch `release-pr` with the updates to `package.json` and `package-lock.json`. The PR MUST be merged to complete the process.
 
 It is not necessary to list this Housekeeping PR in the CHANGELOG, or the PR which updates the CHANGELOG. The goal is to communicate only substantive changes. If PRs are merges with the Squash Merge strategy on GitHub, then the automatic CHANGELOG generation is very neat. If regular merges are used instead, please neaten the CHANGELOG when it is updated.
+
+The `release-pr` branch is updated after the workflow succeeds for **EVERY** release, including edge and stable releases. It must be merged or pulled into the base branch else the release workflow **will fail** on subsequent attempts to publish further releases.


### PR DESCRIPTION
Fix #312

Now that the release workflow has been tested a little more extensively and the failure scenarios are better understood, we can add this bit of extra rich detail in the `DEVELOPMENT.md`.