### PR TITLE
Move Reconcile ahead of Suspend in menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -387,6 +387,11 @@
 					"group": "navigation@0"
 				},
 				{
+					"command": "gitops.flux.reconcileWorkload",
+					"when": "view == gitops.views.workloads && viewItem =~ /(Kustomization;|HelmRelease;)/",
+					"group": "navigation@0"
+				},
+				{
 					"command": "gitops.suspend",
 					"when": "view =~ /(gitops.views.sources|gitops.views.workloads)/ && viewItem =~ /(GitRepository;|Kustomization;|HelmRelease;)/ && viewItem =~ /notSuspend;/",
 					"group": "navigation@1"
@@ -405,11 +410,6 @@
 					"command": "gitops.views.pullGitRepository",
 					"when": "view == gitops.views.sources && viewItem =~ /GitRepository;/",
 					"group": "navigation@3"
-				},
-				{
-					"command": "gitops.flux.reconcileWorkload",
-					"when": "view == gitops.views.workloads && viewItem =~ /(Kustomization;|HelmRelease;)/",
-					"group": "navigation@2"
 				},
 				{
 					"command": "gitops.editor.showLogs",


### PR DESCRIPTION
The menu for Sources places "Reconcile" at the top, and the menu for Workloads (Kustomizations) placed "Reconcile" under "Suspend" instead. This is clearly intolerable (thanks for noticing, to whom reported this) – the change here fixes this.