### PR TITLE
Sort order

### DIFF
--- a/src/views/dataProviders/sourceDataProvider.ts
+++ b/src/views/dataProviders/sourceDataProvider.ts
@@ -6,6 +6,9 @@ import { GitRepositoryNode } from '../nodes/gitRepositoryNode';
 import { HelmRepositoryNode } from '../nodes/helmRepositoryNode';
 import { SourceNode } from '../nodes/sourceNode';
 import { DataProvider } from './dataProvider';
+import { GitRepositoryResult } from '../../kubernetes/gitRepository';
+import { HelmRepositoryResult } from '../../kubernetes/helmRepository';
+import { BucketResult } from '../../kubernetes/bucket';
 
 /**
  * Defines Sources data provider for loading Git/Helm repositories
@@ -57,5 +60,47 @@ export class SourceDataProvider extends DataProvider {
 		statusBar.stopLoadingTree();
 
 		return treeItems;
+	}
+
+	sortGitsByMetadataName(gits: GitRepositoryResult): GitRepositoryResult['items'] {
+		return gits.items.sort((g1, g2) => {
+			if (g1.metadata.name && g2.metadata.name) {
+				if (g1.metadata.name > g2.metadata.name) {
+					return 1;
+				}
+				if (g1.metadata.name < g2.metadata.name) {
+					return -1;
+				}
+			}
+			return 0;
+		});
+	}
+
+	sortHelmsByMetadataName(helms: HelmRepositoryResult): HelmRepositoryResult['items'] {
+		return helms.items.sort((h1, h2) => {
+			if (h1.metadata.name && h2.metadata.name) {
+				if (h1.metadata.name > h2.metadata.name) {
+					return 1;
+				}
+				if (h1.metadata.name < h2.metadata.name) {
+					return -1;
+				}
+			}
+			return 0;
+		});
+	}
+
+	sortBucketsByMetadataName(buckets: BucketResult): BucketResult['items'] {
+		return buckets.items.sort((b1, b2) => {
+			if (b1.metadata.name && b2.metadata.name) {
+				if (b1.metadata.name > b2.metadata.name) {
+					return 1;
+				}
+				if (b1.metadata.name < b2.metadata.name) {
+					return -1;
+				}
+			}
+			return 0;
+		});
 	}
 }

--- a/src/views/dataProviders/workloadDataProvider.ts
+++ b/src/views/dataProviders/workloadDataProvider.ts
@@ -45,13 +45,33 @@ export class WorkloadDataProvider extends DataProvider {
 		this.namespaceResult = namespaces;
 
 		if (kustomizations) {
-			for (const kustomizeWorkload of kustomizations.items) {
+			for (const kustomizeWorkload of kustomizations.items.sort((k1, k2) => {
+				if (k1.metadata.name && k2.metadata.name) {
+					if (k1.metadata.name > k2.metadata.name) {
+						return 1;
+					}
+					if (k1.metadata.name < k2.metadata.name) {
+						return -1;
+					}
+				}
+				return 0;
+			})) {
 				workloadNodes.push(new KustomizationNode(kustomizeWorkload));
 			}
 		}
 
 		if (helmReleases) {
-			for (const helmRelease of helmReleases.items) {
+			for (const helmRelease of helmReleases.items.sort((h1, h2) => {
+				if (h1.metadata.name && h2.metadata.name) {
+					if (h1.metadata.name > h2.metadata.name) {
+						return 1;
+					}
+					if (h1.metadata.name < h2.metadata.name) {
+						return -1;
+					}
+				}
+				return 0;
+			})) {
 				workloadNodes.push(new HelmReleaseNode(helmRelease));
 			}
 		}

--- a/src/views/dataProviders/workloadDataProvider.ts
+++ b/src/views/dataProviders/workloadDataProvider.ts
@@ -12,6 +12,8 @@ import { TreeNode } from '../nodes/treeNode';
 import { WorkloadNode } from '../nodes/workloadNode';
 import { refreshWorkloadsTreeView } from '../treeViews';
 import { DataProvider } from './dataProvider';
+import { HelmReleaseResult } from '../../kubernetes/helmRelease';
+import { KustomizeResult } from '../../kubernetes/kustomize';
 
 /**
  * Defines data provider for loading Kustomizations
@@ -45,33 +47,13 @@ export class WorkloadDataProvider extends DataProvider {
 		this.namespaceResult = namespaces;
 
 		if (kustomizations) {
-			for (const kustomizeWorkload of kustomizations.items.sort((k1, k2) => {
-				if (k1.metadata.name && k2.metadata.name) {
-					if (k1.metadata.name > k2.metadata.name) {
-						return 1;
-					}
-					if (k1.metadata.name < k2.metadata.name) {
-						return -1;
-					}
-				}
-				return 0;
-			})) {
+			for (const kustomizeWorkload of this.sortKsByMetadataName(kustomizations)) {
 				workloadNodes.push(new KustomizationNode(kustomizeWorkload));
 			}
 		}
 
 		if (helmReleases) {
-			for (const helmRelease of helmReleases.items.sort((h1, h2) => {
-				if (h1.metadata.name && h2.metadata.name) {
-					if (h1.metadata.name > h2.metadata.name) {
-						return 1;
-					}
-					if (h1.metadata.name < h2.metadata.name) {
-						return -1;
-					}
-				}
-				return 0;
-			})) {
+			for (const helmRelease of this.sortHrByMetadataName(helmReleases)) {
 				workloadNodes.push(new HelmReleaseNode(helmRelease));
 			}
 		}
@@ -85,6 +67,33 @@ export class WorkloadDataProvider extends DataProvider {
 		statusBar.stopLoadingTree();
 
 		return workloadNodes;
+	}
+
+	sortKsByMetadataName(kss: KustomizeResult): KustomizeResult['items'] {
+		return kss.items.sort((k1, k2) => {
+			if (k1.metadata.name && k2.metadata.name) {
+				if (k1.metadata.name > k2.metadata.name) {
+					return 1;
+				}
+				if (k1.metadata.name < k2.metadata.name) {
+					return -1;
+				}
+			}
+			return 0;
+		});
+	}
+	sortHrByMetadataName(hrr: HelmReleaseResult): HelmReleaseResult['items'] {
+		return hrr.items.sort((h1, h2) => {
+			if (h1.metadata.name && h2.metadata.name) {
+				if (h1.metadata.name > h2.metadata.name) {
+					return 1;
+				}
+				if (h1.metadata.name < h2.metadata.name) {
+					return -1;
+				}
+			}
+			return 0;
+		});
 	}
 
 	buildWorkloadsTree(node: TreeNode, resourceTree: FluxTreeResources[], parentNamespace = '') {


### PR DESCRIPTION
This has been tested as #276 and is in edge releases now

The sort order is augmented with a Kind/Name partition sort. The resources are presented grouped by kind, and ordered by name. This is true in both Sources and Workloads tree views.