### PR TITLE
Set kubeconfig from upstream

### DIFF
--- a/package.json
+++ b/package.json
@@ -330,6 +330,11 @@
 					"when": "view == gitops.views.clusters"
 				},
 				{
+					"command": "extension.vsKubernetesUseKubeconfig",
+					"group": "1",
+					"when": "view == gitops.views.clusters"
+				},
+				{
 					"command": "gitops.editor.createSource",
 					"group": "navigation@0",
 					"when": "view == gitops.views.sources"

--- a/src/views/treeViews.ts
+++ b/src/views/treeViews.ts
@@ -12,6 +12,8 @@ import { ClusterContextNode } from './nodes/clusterContextNode';
 import { TreeNode } from './nodes/treeNode';
 import { Views } from './views';
 
+import * as k8s from 'vscode-kubernetes-tools-api';
+
 export let clusterTreeViewProvider: ClusterDataProvider;
 export let sourceTreeViewProvider: SourceDataProvider;
 export let workloadTreeViewProvider: WorkloadDataProvider;
@@ -52,6 +54,28 @@ export function createTreeViews() {
 	documentationTreeView = window.createTreeView(Views.DocumentationView, {
 		treeDataProvider: documentationTreeViewProvider,
 		showCollapseAll: true,
+	});
+
+	refreshWhenK8sContextChange();
+	detectK8sConfigPathChange();
+}
+
+async function refreshWhenK8sContextChange() {
+	const configuration = await k8s.extension.configuration.v1_1;
+	if (!configuration.available) {
+		return;
+	}
+	configuration.api.onDidChangeContext(_context => {
+		refreshAllTreeViews();
+	});
+}
+async function detectK8sConfigPathChange() {
+	const configuration = await k8s.extension.configuration.v1_1;
+	if (!configuration.available) {
+		return;
+	}
+	configuration.api.onDidChangeKubeconfigPath(_path => {
+		refreshAllTreeViews();
 	});
 }
 


### PR DESCRIPTION
Targeting #266 

- [X] Add the "Set Kubeconfig" widget to our Clusters tree view, matching the portal experience of the Kubernetes Tools
- [x] Subscribe to the refresh events

The refresh events can be subscribed to, so users will not usually have to remember to manually refresh the Clusters tree after each "Set kubeconfig" – or to stay in sync with what users may do on the Kubernetes tab, if they are using that one.