### PR TITLE
Make release process slightly better documented

### DIFF
--- a/.github/workflows/build-vsix.yml
+++ b/.github/workflows/build-vsix.yml
@@ -174,17 +174,34 @@ jobs:
           tag: ${{ env.GIT_TAG }}
           prerelease: ${{ github.event.inputs.releaseChannel == 'edge' }}
 
-          # We need to use a pull request because we don't want to make an exception for
-          # our main branch "no push without a pull request" even for some robot. So just merge this PR.
+          # We need to use a pull request because we need tags to be included in the history of our main
+          # branch. We don't want to make an exception for our "no pushes without a pull request" security
+          # policy, even for some robot. So just merge this PR manually to complete each release, or do a
+          # fast-forward of the edge branch catching it up to the `release-pr` branch, as it won't get the
+          # PR. (If you have trouble publishing more than one edge release, this mistake is usually why.)
       - uses: repo-sync/pull-request@v2
-        name: pull-request
+        name: Finish Release PR
         if: ${{ github.event.inputs.releaseChannel != 'edge' }}
         with:
           source_branch: "release-pr"
           destination_branch: "main"
           pr_title: "Release ${{ env.GIT_TAG }}"
-          pr_body: "A release has been tagged as ${{ env.GIT_TAG }}. Merge this PR to main to complete it."
-          pr_reviewer: "kingdonb"
+          pr_body: |-
+            A release has been tagged and published, `${{ env.GIT_TAG }}`! 🎉
+            Ensure the CHANGELOG is updated by pushing it to this branch, (or skip this step and save it for MINOR releases.)
+            A CHANGELOG has been generated here,
+            [`${{ env.GIT_TAG }}`](https://github.com/weaveworks/vscode-gitops-tools/releases/tag/${{ env.GIT_TAG }})
+            you can copy directly from it, or edit the messages for uniformity and clarity.
+            
+            When you are done, merge this PR with the tag (**Do Not Squash** or rebase!
+            Push new commits and **merge only**) in order to complete the release.
+            
+            Feature branches should normally be squashed, but this one must be merged to include the tag in the main branch's history.
+            
+            The tag must be in the default branch, so the release machine can know what patch version
+            to use next, and for auto CHANGELOG generation to know when to stop reading in changes, as
+            the CHANGELOG generator will scan gathering history, all the way up until the previous tag.
+          pr_reviewer: ${{ github.actor }}
           pr_draft: false
           github_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -33,18 +33,24 @@ Install from `.vsix` file step is only required for testing the latest version o
 
 In order to release a new version the extension, visit the Publish action from [build-vsix.yaml](https://github.com/weaveworks/vscode-gitops-tools/actions/workflows/build-vsix.yml) and run the workflow as a `workflow_dispatch` trigger.
 
-Choose a branch: `main` or `edge`, and set the parameters of Release Type (major, minor, patch) then use the Release Channel (stable) or (prerelease). Stable releases correspond to the `main` branch and prereleases should come from `edge`.
+Choose a branch: `main` or `edge`, and set the parameters of Release Type (major, minor, patch) then use the Release Channel (stable) or (prerelease). Stable releases correspond to the `main` branch and prereleases should come from `edge`. Note: The release will be blocked if this is incorrect.
 
 Publish on Visual Studio Marketplace (yes), currently the Open VSX Registry is not supported.
 
-Add your entries to CHANGELOG before publishing the release (or after publishing, in the event that patches are being published frequently the CHANGELOG may be allowed to fall behind, but should be updated in the tree for MINOR releases.)
+The release process will update CHANGELOG and populate releases with a list of changes. This looks nicer if "Squash and Merge" is used when feature branches are completed.
 
-The release process will update CHANGELOG and populate releases with a list of changes. This looks nicer if "Squash and Merge" is used.
+Update the CHANGELOG after the release, or earlier for over-achievers. (You can use the generated CHANGELOG otherwise.)
 
-It is not necessary to increment the version number manually in package.json, the release workflow takes care of this.
+It is not ever necessary to increment the version number manually in package.json, the release workflow takes care of this.
 
-**Important:** Upon success, the Publish workflow will have created a new GitHub release, pushed the tag, added the CHANGELOG, and submitted a PR from the branch `release-pr` with the updates to `package.json` and `package-lock.json`. The PR MUST be merged to complete the process.
+**Important:** Upon success, the Publish workflow will have created a new GitHub release, pushed the tag, added the CHANGELOG, and submitted a PR from the branch `release-pr` with the updates to `package.json` and `package-lock.json`. The PR MUST be merged to complete the process. If you triggered the release, then you will be tagged as a `pr_reviewer` based on `${{ github.actor }}`
 
 It is not necessary to list this Housekeeping PR in the CHANGELOG, or the PR which updates the CHANGELOG. The goal is to communicate only substantive changes. If PRs are merges with the Squash Merge strategy on GitHub, then the automatic CHANGELOG generation is very neat. If regular merges are used instead, please neaten the CHANGELOG when it is updated.
 
 The `release-pr` branch is updated after the workflow succeeds for **EVERY** release, including edge and stable releases. It must be merged or pulled into the base branch else the release workflow **will fail** on subsequent attempts to publish further releases.
+
+If you are doing an edge release, there is no CHANGELOG generated since edge releases are for moving fast and breaking things. Therefore edge branches, like spike commits or spike branches, usually shouldn't be merged at all when they are done, but abandoned instead. Feature branches when they have been vetted thoroughly should be squashed and re-written, or cherry-picked for inclusion in the main branch. It's not safe to assume that anything else which has been merged into the edge branch can be released to stable now without reviewing everything first.
+
+(If you are confident that you have not broken anything, and there aren't any other unreviewed changes in the edge branch, it should be safe to squash and merge it back to the main branch only before a MINOR release. This is OK because the patch number must be maintained internallyas semver, but it is not significant in edge releases due to a quirk of the VS Code Extension marketplace.)
+
+Our release process for the VS Code Extension Marketplace was not an original creation designed entirely in-house: see [The GitHub Action You Need to Publish VS Code Extensions](https://www.stateful.com/blog/the-github-action-you-need-to-publish-vscode-extensions) for the original work which was modified slightly to make the [build-vsix.yaml](/.github/workflows/build-vsix.yaml) workflow that is used here.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -45,12 +45,23 @@ It is not ever necessary to increment the version number manually in package.jso
 
 **Important:** Upon success, the Publish workflow will have created a new GitHub release, pushed the tag, added the CHANGELOG, and submitted a PR from the branch `release-pr` with the updates to `package.json` and `package-lock.json`. The PR MUST be merged to complete the process. If you triggered the release, then you will be tagged as a `pr_reviewer` based on `${{ github.actor }}`
 
-It is not necessary to list this Housekeeping PR in the CHANGELOG, or the PR which updates the CHANGELOG. The goal is to communicate only substantive changes. If PRs are merges with the Squash Merge strategy on GitHub, then the automatic CHANGELOG generation is very neat. If regular merges are used instead, please neaten the CHANGELOG when it is updated.
+Callout:
+* For all future VS Code Exception developers, here is the release workflow "squash merge" exception
 
-The `release-pr` branch is updated after the workflow succeeds for **EVERY** release, including edge and stable releases. It must be merged or pulled into the base branch else the release workflow **will fail** on subsequent attempts to publish further releases.
+All PRs are expected to be "squashed when merged" except for the release-pr. You will only need to know this information if you are a maintainer merging feature contributions, or if you are actually the one physically doing releases.
 
-If you are doing an edge release, there is no CHANGELOG generated since edge releases are for moving fast and breaking things. Therefore edge branches, like spike commits or spike branches, usually shouldn't be merged at all when they are done, but abandoned instead. Feature branches when they have been vetted thoroughly should be squashed and re-written, or cherry-picked for inclusion in the main branch. It's not safe to assume that anything else which has been merged into the edge branch can be released to stable now without reviewing everything first.
+If you are merging a feature branch, it is a "Squash and merge"
+If you are merging the release-pr branch, "Create a merge commit"
+
+
+It is not necessary to list this Housekeeping PR in the CHANGELOG (or the PR which updates the CHANGELOG if it is a separate PR.) The goal of the CHANGELOG is to communicate only substantive changes. If PRs are merges with the Squash Merge strategy on GitHub, then the automatic CHANGELOG generation is very neat.
+
+If regular merges have been used instead, please neaten the CHANGELOG when it is updated as it will have an entry for each and every commit.
+
+The `release-pr` branch is updated after the workflow succeeds for **EVERY** release, including edge and stable releases. It must be merged or pulled into the base branch else the release workflow **will fail** on subsequent attempts to publish further releases. It needs to know the last tag that was used, it does read `package.json` rather than try to find this out by scanning the branch history for a previous tag.
+
+If you are doing an edge release, there is no CHANGELOG generated since edge releases are for moving fast and breaking things. Therefore edge branches, like spike commits or spike branches, usually shouldn't be merged at all when they are done, but abandoned instead. Feature branches when they have been vetted thoroughly should be squashed and re-written, or cherry-picked for inclusion in the main branch. It's never safe to assume that anything else which has been merged into the edge branch can be released to stable now without reviewing everything first.
 
 (If you are confident that you have not broken anything, and there aren't any other unreviewed changes in the edge branch, it should be safe to squash and merge it back to the main branch only before a MINOR release. This is OK because the patch number must be maintained internallyas semver, but it is not significant in edge releases due to a quirk of the VS Code Extension marketplace.)
 
-Our release process for the VS Code Extension Marketplace was not an original creation designed entirely in-house: see [The GitHub Action You Need to Publish VS Code Extensions](https://www.stateful.com/blog/the-github-action-you-need-to-publish-vscode-extensions) for the original work which was modified slightly to make the [build-vsix.yaml](/.github/workflows/build-vsix.yaml) workflow that is used here.
+Our release process for the VS Code Extension Marketplace was not an original creation designed entirely in-house: see [The GitHub Action You Need to Publish VS Code Extensions](https://www.stateful.com/blog/the-github-action-you-need-to-publish-vscode-extensions) for the original work which was modified very slightly to make the [build-vsix.yaml](/.github/workflows/build-vsix.yaml) workflow that is used here.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -56,7 +56,7 @@ All PRs are expected to be "squashed when merged" except for the release-pr. You
 * If you are merging the release-pr branch, "Create a merge commit"
 
 
-It is not necessary to list this Housekeeping PR in the CHANGELOG (or the PR which updates the CHANGELOG if it is a separate PR.) The goal of the CHANGELOG is to communicate only substantive changes. If PRs are merges with the Squash Merge strategy on GitHub, then the automatic CHANGELOG generation is very neat and orderly by default.
+It is not necessary to list this Housekeeping PR in the CHANGELOG (or the PR which updates the CHANGELOG if it is a separate PR.) The goal of the CHANGELOG is to communicate only substantive changes. If PRs are merged with the Squash Merge strategy on GitHub, then the automatic CHANGELOG generation is very neat and orderly by default.
 
 If regular merges have been used instead, please neaten the CHANGELOG when it is updated as it will have an entry for each and every commit, and this may look very messy. (This is why we squash feature branches.)
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -43,20 +43,22 @@ Update the CHANGELOG after the release, or earlier for over-achievers. (You can 
 
 It is not ever necessary to increment the version number manually in package.json, the release workflow takes care of this.
 
-**Important:** Upon success, the Publish workflow will have created a new GitHub release, pushed the tag, added the CHANGELOG, and submitted a PR from the branch `release-pr` with the updates to `package.json` and `package-lock.json`. The PR MUST be merged to complete the process. If you triggered the release, then you will be tagged as a `pr_reviewer` based on `${{ github.actor }}`
+**Important:** Upon success, the Publish workflow will have created a new GitHub release, pushed the tag, added the CHANGELOG to the release body, and submitted a PR from the branch `release-pr` with a change containing the version number updates to `package.json` and `package-lock.json`, the tagged commit. The PR MUST be merged to complete the release process.
+
+If you triggered the release, then you will be auto-tagged as a `pr_reviewer` based on `${{ github.actor }}`
 
 Callout:
 * For all future VS Code Exception developers, here is the release workflow "squash merge" exception
 
 All PRs are expected to be "squashed when merged" except for the release-pr. You will only need to know this information if you are a maintainer merging feature contributions, or if you are actually the one physically doing releases.
 
-If you are merging a feature branch, it is a "Squash and merge"
-If you are merging the release-pr branch, "Create a merge commit"
+* If you are merging a feature branch, it is a "Squash and merge"
+* If you are merging the release-pr branch, "Create a merge commit"
 
 
-It is not necessary to list this Housekeeping PR in the CHANGELOG (or the PR which updates the CHANGELOG if it is a separate PR.) The goal of the CHANGELOG is to communicate only substantive changes. If PRs are merges with the Squash Merge strategy on GitHub, then the automatic CHANGELOG generation is very neat.
+It is not necessary to list this Housekeeping PR in the CHANGELOG (or the PR which updates the CHANGELOG if it is a separate PR.) The goal of the CHANGELOG is to communicate only substantive changes. If PRs are merges with the Squash Merge strategy on GitHub, then the automatic CHANGELOG generation is very neat and orderly by default.
 
-If regular merges have been used instead, please neaten the CHANGELOG when it is updated as it will have an entry for each and every commit.
+If regular merges have been used instead, please neaten the CHANGELOG when it is updated as it will have an entry for each and every commit, and this may look very messy. (This is why we squash feature branches.)
 
 The `release-pr` branch is updated after the workflow succeeds for **EVERY** release, including edge and stable releases. It must be merged or pulled into the base branch else the release workflow **will fail** on subsequent attempts to publish further releases. It needs to know the last tag that was used, it does read `package.json` rather than try to find this out by scanning the branch history for a previous tag.
 


### PR DESCRIPTION
Tl;dr: it's not inconsistent if the exception is documented.

For all future VS Code Exception developers, here is the release workflow "squash merge" exception

All PRs are expected to be "squashed when merged" except for the `release-pr`. You will only need to know this information if you are a maintainer merging feature contributions, or if you are actually the one physically doing releases.

* If you are merging a feature branch, it is a "**Squash and merge**"
* If you are merging the `release-pr` branch, "**Create a merge commit**"

This unfortunately erases some history inside of a feature branch.

I do not have a good solution for that issue, but I hope it will not be too onerous if we keep feature branches small.

It was necessary to make this compromise in order to achieve a fully auto-generated `CHANGELOG` together with a release machine that handles the version incrementing on our behalf. Release engineers will only need to know if a release includes any breaking change or new feature in the public API to determine whether it should be a MAJOR, MINOR or PATCH release.