### PR TITLE
add Flux to the name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "vscode-gitops-tools",
-	"displayName": "GitOps Tools",
+	"displayName": "GitOps Tools for Flux",
 	"description": "GitOps automation tools for continuous delivery of Kubernetes and Cloud Native applications",
 	"version": "0.20.7",
 	"author": "Kingdon Barrett <kingdon@weave.works>",


### PR DESCRIPTION
We are not even on the top 1 page of search results for "Flux" and we already have more downloads than most of these extensions, it can only be this way because we do not have Flux in the name. 🤦

Let's publish a release that has "Flux" in the name. Based on [StackOverflow](https://stackoverflow.com/questions/49209327/if-i-change-my-vs-code-extensions-name-will-i-lose-the-downloads-statistics) we can do that without losing any statistics or following. It should be not controversial to merge this change, as if it turned out to be a bad idea for any reason, we can always set it back.

I think we should put out a release today just to fix this.