### PR TITLE
Add relevant metadata to markdown table for OCI

### DIFF
--- a/src/utils/markdownUtils.ts
+++ b/src/utils/markdownUtils.ts
@@ -49,6 +49,9 @@ export function createMarkdownTable(kubernetesObject: KnownTreeNodeResources): M
 		createMarkdownTableRow('spec.ref.semver', kubernetesObject.spec?.ref?.semver, markdown);
 	} else if (kubernetesObject.kind === KubernetesObjectKinds.OCIRepository) {
 		createMarkdownTableRow('spec.url', kubernetesObject.spec?.url, markdown);
+		createMarkdownTableRow('spec.ref.digest', kubernetesObject.spec?.ref?.digest, markdown);
+		createMarkdownTableRow('spec.ref.semver', kubernetesObject.spec?.ref?.semver, markdown);
+		createMarkdownTableRow('spec.ref.tag', kubernetesObject.spec?.ref?.tag, markdown);
 	} else if (kubernetesObject.kind === KubernetesObjectKinds.HelmRepository) {
 		createMarkdownTableRow('spec.url', kubernetesObject.spec?.url, markdown);
 		createMarkdownTableRow('spec.type', kubernetesObject.spec?.type, markdown);


### PR DESCRIPTION
One of these will be set at least, or the OCIRepository should default to pulling the 'latest' tag (which is fine if you like, sure, but that would not be GitOps anymore...)

Anyway, this information provides the needed context for the user to understand which tag will be selected and how by the `OCIRepository` whenever it reconciles, or if rather digest pinning is in use, then which specific tag it carries in its artifact.