### PR TITLE
Build flux OCI in main branch

### DIFF
--- a/.github/workflows/build-flux-oci-prerelease.yaml
+++ b/.github/workflows/build-flux-oci-prerelease.yaml
@@ -1,0 +1,77 @@
+name: Build Flux OCI Binary (Pre-release)
+
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  flux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '^1.17.0'
+
+      - name: Prepare
+        id: prep
+        run: |
+          FLUX_PATH=${GITHUB_WORKSPACE}/bin
+          # FLUX_OCI_SHA=ce2496e32ca29f183467b5ce2ae779310d9da9de
+          # mkdir flux2 && pushd flux2
+          # git init
+          # git remote add origin https://github.com/fluxcd/flux2
+          git clone --depth 1 https://github.com/fluxcd/flux2 -b oci
+          # git fetch --depth 1 origin $FLUX_OCI_SHA
+          # git checkout FETCH_HEAD
+          pushd flux2
+          FLUX_OCI_SHA=$(git rev-parse --short HEAD)
+          popd
+          mkdir -p "${FLUX_PATH}"
+          echo "${FLUX_PATH}" >> $GITHUB_PATH
+      
+          echo ::set-output name=FLUX_PATH::${FLUX_PATH}
+          echo ::set-output name=FLUX_OCI_SHA::${FLUX_OCI_SHA}
+
+      - id: go-cache-paths
+        run: |
+          echo "::set-output name=go-build::$(go env GOCACHE)"
+          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+
+      - name: Cache Flux OCI (prerelease)
+        id: cache-flux
+        uses: actions/cache@v3
+        env:
+          cache-name: flux
+        with:
+          path: ${{ steps.prep.outputs.FLUX_PATH }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ steps.prep.outputs.FLUX_OCI_SHA }}
+
+      - name: Go Build Cache
+        if: steps.cache-flux.outputs.cache-hit != 'true'
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-build }}
+          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+
+      - name: Go Mod Cache
+        if: steps.cache-flux.outputs.cache-hit != 'true'
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-mod }}
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+
+      - name: Build Flux (pre-release)
+        if: steps.cache-flux.outputs.cache-hit != 'true'
+        id: build-flux-oci
+        run: |
+          pushd flux2
+          make build
+          cp bin/flux ${{ steps.prep.outputs.FLUX_PATH }}
+          popd
+
+      - uses: actions/upload-artifact@v2
+        if: steps.cache-flux.outputs.cache-hit != 'true'
+        with:
+          name: flux-oci-bin-prerelease
+          path: ${{ steps.prep.outputs.FLUX_PATH }}/flux


### PR DESCRIPTION
There is only one way to populate this cache for tags and other branches and that is to execute this in the main branch. So although we are not yet ready to release Flux OCI, this can go in the main branch today.

It will only be used by CI builds that access it (ref: next PR targeting edge branch)