### PR TITLE
Add prerelease metadata

### DIFF
--- a/.github/scripts/updateEdgeVersion.js
+++ b/.github/scripts/updateEdgeVersion.js
@@ -21,6 +21,7 @@ const newVersion = pkg.version.split('.').slice(0, 2)
 const prereleaseDate = Math.floor(Date.now() / 1000);
 newVersion.push(prereleaseDate);
 pkg.version = `${newVersion.join('.')}`;
+pkg.__metadata.isPreReleaseVersion = true;
 
 console.log(`Update package.json with Edge version:\n\n${JSON.stringify(pkg, null, 2)}`);
 fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-gitops-tools",
-	"version": "0.20.10-edge.1",
+	"version": "0.20.10-edge.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-gitops-tools",
-			"version": "0.20.10-edge.1",
+			"version": "0.20.10-edge.2",
 			"license": "MPL-2.0",
 			"dependencies": {
 				"@kubernetes/client-node": "^0.16.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-gitops-tools",
 	"displayName": "GitOps Tools for Flux",
 	"description": "GitOps automation tools for continuous delivery of Kubernetes and Cloud Native applications",
-	"version": "0.20.10-edge.1",
+	"version": "0.20.10-edge.2",
 	"author": "Kingdon Barrett <kingdon@weave.works>",
 	"contributors": [
 		"Kingdon Barrett <kingdon@weave.works>",


### PR DESCRIPTION
I noticed that OpenVSX `ovsx` CLI does not update releases during publish with the prerelease metadata, and it seems this prevents my releases from being handled as a prerelease when they are published to OpenVSX (?)

Testing.