### PR TITLE
Don't peg every context on startup

### DIFF
--- a/src/views/dataProviders/clusterDataProvider.ts
+++ b/src/views/dataProviders/clusterDataProvider.ts
@@ -95,13 +95,16 @@ export class ClusterDataProvider extends DataProvider {
 					}
 				}
 			}
+			if(clusterNode.isCurrent) {
+				this.updateClusterContext(clusterNode);
+			}
 			clusterNodes.push(clusterNode);
 		}
 
 		// Update async status of the deployments (flux commands take a while to run)
 		this.updateDeploymentStatus(currentContextTreeItem);
 		// Update async cluster context/icons
-		this.updateClusterContexts(clusterNodes);
+		// this.updateClusterContexts(clusterNodes);
 
 		statusBar.stopLoadingTree();
 		setVSCodeContext(ContextTypes.LoadingClusters, false);
@@ -147,10 +150,20 @@ export class ClusterDataProvider extends DataProvider {
 	 * Update cluster context for all cluster nodes one by one.
 	 * @param clusterNodes all cluster nodes in this tree view.
 	 */
+	// TODO: FIXME: calling this is a bad idea with more than 10-100 contexts
 	async updateClusterContexts(clusterNodes: ClusterContextNode[]) {
 		await Promise.all(clusterNodes.map(async clusterNode => {
 			await clusterNode.updateNodeContext();
 			refreshClustersTreeView(clusterNode);
 		}));
+	}
+
+	/**
+	 * Update cluster context for a single cluster node.
+	 * @param clusterNode Usually the selected clusterNode.
+	 */
+	async updateClusterContext(clusterNode: ClusterContextNode) {
+		await clusterNode.updateNodeContext();
+		refreshClustersTreeView(clusterNode);
 	}
 }


### PR DESCRIPTION
Tested in the prerelease channel as #371

This change ensures that the extension only talks to the active/selected kubeconfig in the startup sequence.

We may need to add more changes so that the refresh button has the same behavior, or make a way for the user to cancel that activity / time it out. It has to work for a user who has hundreds of clusters in their default `KUBECONFIG`.

I think this change should be aimed at addressing some residual forms of either of these issues:

* #239 
* #267 

Marked as draft because I think this does not go far enough yet, (and waiting for confirmation from the user who reported.)