### PR TITLE
Point at a stable target from tests

### DIFF
--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -100,7 +100,7 @@ suite('Extension Test Suite', () => {
 	test('OCI Sources are listed', async function() {
 		this.timeout(15000);
 
-		await api.shell.execWithOutput('flux create source oci podinfo --url=oci://ghcr.io/kingdonb/podinfo/deploy --tag-semver 6.1.x');
+		await api.shell.execWithOutput('flux create source oci podinfo --url=oci://ghcr.io/stefanprodan/manifests/podinfo --tag-semver 6.1.x');
 		await vscode.commands.executeCommand('gitops.views.refreshSourceTreeView');
 
 		let source = await getTreeItem(api.data.sourceTreeViewProvider, 'OCIRepository: podinfo');


### PR DESCRIPTION
The stefanprodan/manifests/podinfo repo is unlikely to move, but kingdonb/podinfo/deploy is an experiment that did not wind up where I wanted it, and it should go away.

But I cannot delete it now without GitHub Support getting involved, because we called that image nearly 10,000 times already from the tests (and repos which are over 5000 cannot be manually deleted without getting someone else involved.)

😱🤩🤯