### PR TITLE
Release 0.22.1 again as 0.22.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-gitops-tools",
-	"version": "0.22.0",
+	"version": "0.22.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-gitops-tools",
-			"version": "0.22.0",
+			"version": "0.22.1",
 			"license": "MPL-2.0",
 			"dependencies": {
 				"@kubernetes/client-node": "^0.16.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-gitops-tools",
 	"displayName": "GitOps Tools for Flux",
 	"description": "GitOps automation tools for continuous delivery of Kubernetes and Cloud Native applications",
-	"version": "0.22.0",
+	"version": "0.22.1",
 	"author": "Kingdon Barrett <kingdon@weave.works>",
 	"contributors": [
 		"Kingdon Barrett <kingdon@weave.works>",


### PR DESCRIPTION
Something at GitHub Actions failed, the release was hanging for over an hour, it's already been published at Microsoft VSCode Marketplace, but it isn't published for OpenVSX. Just bump the number and try again.

Signed-off-by: Kingdon Barrett <kingdon@weave.works>