### PR TITLE
test: timeout kustomizations that wont reconcile

### DIFF
--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -116,7 +116,7 @@ suite('Extension Test Suite', () => {
 	test('Kustomizations are listed', async function() {
 		this.timeout(10000);
 
-		await api.shell.execWithOutput('flux create kustomization podinfo --target-namespace=default --source=podinfo --path="./kustomize"');
+		await api.shell.execWithOutput('flux create kustomization podinfo --target-namespace=default --source=podinfo --path="./kustomize" --timeout=5s');
 		await vscode.commands.executeCommand('gitops.views.refreshWorkloadTreeView');
 
 		let workload = await getTreeItem(api.data.workloadTreeViewProvider, 'podinfo');


### PR DESCRIPTION
Correct the test timeout that appeared on [71960eb](https://github.com/weaveworks/vscode-gitops-tools/commit/71960eb932eef3ecca07a5eec927e166f7de34f9) ([Details](https://github.com/weaveworks/vscode-gitops-tools/actions/runs/3329624905/jobs/5820778555))