### PR TITLE
Pinning kind action to master does not work

### DIFF
--- a/.github/workflows/build-vsix.yml
+++ b/.github/workflows/build-vsix.yml
@@ -94,7 +94,7 @@ jobs:
         run: npm run compile
 
       - name: Setup Kubernetes
-        uses: engineerd/setup-kind@eb0371b1c9fd37b92d7474a26196f078514de7bf # pin@master
+        uses: engineerd/setup-kind@aa272fe2a7309878ffc2a81c56cfe3ef108ae7d0 # pin@v0.5.0
         with:
           version: v0.19.0
           image: kindest/node:v1.27.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - run: npm install
 
       - name: Setup Kubernetes
-        uses: engineerd/setup-kind@eb0371b1c9fd37b92d7474a26196f078514de7bf # pin@master
+        uses: engineerd/setup-kind@aa272fe2a7309878ffc2a81c56cfe3ef108ae7d0 # pin@v0.5.0
         with:
           version: v0.19.0
           image: kindest/node:v1.27.3


### PR DESCRIPTION
Fix up kind action which for some reason does not work when pinned to master (maybe breaking changes that haven't landed yet, maybe it's written in typescript and they compile in a branch for the release, IDK... just follow the README guide, which pins to 0.5.0)