### PR TITLE
Remove refreshes from reconcile functions

### DIFF
--- a/src/commands/fluxReconcileSource.ts
+++ b/src/commands/fluxReconcileSource.ts
@@ -27,5 +27,5 @@ export async function fluxReconcileSourceCommand(source: GitRepositoryNode | OCI
 
 	await fluxTools.reconcile(sourceType, source.resource.metadata?.name || '', source.resource.metadata?.namespace || '');
 
-	refreshSourcesTreeView();
+	// refreshSourcesTreeView();
 }

--- a/src/commands/fluxReconcileSource.ts
+++ b/src/commands/fluxReconcileSource.ts
@@ -7,7 +7,6 @@ import { BucketNode } from 'ui/treeviews/nodes/source/bucketNode';
 import { GitRepositoryNode } from 'ui/treeviews/nodes/source/gitRepositoryNode';
 import { HelmRepositoryNode } from 'ui/treeviews/nodes/source/helmRepositoryNode';
 import { OCIRepositoryNode } from 'ui/treeviews/nodes/source/ociRepositoryNode';
-import { refreshSourcesTreeView } from 'ui/treeviews/treeViews';
 
 /**
  * Invoke flux reconcile of a specific source.
@@ -26,6 +25,4 @@ export async function fluxReconcileSourceCommand(source: GitRepositoryNode | OCI
 	}
 
 	await fluxTools.reconcile(sourceType, source.resource.metadata?.name || '', source.resource.metadata?.namespace || '');
-
-	// refreshSourcesTreeView();
 }

--- a/src/commands/fluxReconcileWorkload.ts
+++ b/src/commands/fluxReconcileWorkload.ts
@@ -5,7 +5,6 @@ import { FluxWorkload } from 'types/fluxCliTypes';
 import { Kind } from 'types/kubernetes/kubernetesTypes';
 import { HelmReleaseNode } from 'ui/treeviews/nodes/workload/helmReleaseNode';
 import { KustomizationNode } from 'ui/treeviews/nodes/workload/kustomizationNode';
-import { refreshSourcesTreeView, refreshWorkloadsTreeView } from 'ui/treeviews/treeViews';
 
 /**
  * Invoke flux reconcile of a specific workload.
@@ -24,11 +23,6 @@ export async function fluxReconcileWorkload(workload: KustomizationNode | HelmRe
 	}
 
 	await fluxTools.reconcile(workloadType, workload.resource.metadata?.name || '', workload.resource.metadata?.namespace || '', withSource);
-
-	// refreshWorkloadsTreeView(workload);
-	// if(withSource) {
-	// 	refreshSourcesTreeView();
-	// }
 }
 
 

--- a/src/commands/fluxReconcileWorkload.ts
+++ b/src/commands/fluxReconcileWorkload.ts
@@ -25,10 +25,10 @@ export async function fluxReconcileWorkload(workload: KustomizationNode | HelmRe
 
 	await fluxTools.reconcile(workloadType, workload.resource.metadata?.name || '', workload.resource.metadata?.namespace || '', withSource);
 
-	refreshWorkloadsTreeView();
-	if(withSource) {
-		refreshSourcesTreeView();
-	}
+	// refreshWorkloadsTreeView(workload);
+	// if(withSource) {
+	// 	refreshSourcesTreeView();
+	// }
 }
 
 


### PR DESCRIPTION
Fix #450

I gave this a local test as 0.25.0-pre.3 and it didn't seem to harm anything!

If I made the source and the kustomization both visible, then they are both still visible after reconcile with source. There should be no need to call refresh, if we have sent async reconciles to the resource, and all visible resources are already in the informer's subscriptions, then I think we don't need to call refresh, we'll just get a callback when it's happening.

In my test, this made it possible to briefly observe the Kustomization's temporary unready state while it was reconciling. The git repo was definitely reconciled through the command, but the visible representation didn't budge, possibly because I was reconciling a repo that had no changes, so there was never going to be any progress to report from the Git Repository's end.

I will test this more, if there are other calls to refresh we should remove them too. I think we generally don't need to call that function anymore, except for as a response to the user's request when they manually click the button to ask for a refresh.