### PR TITLE
(Prerelease) Allow users to disable running `flux check`

### DIFF
--- a/package.json
+++ b/package.json
@@ -278,6 +278,11 @@
 		"configuration": {
 			"title": "GitOps Tools",
 			"properties": {
+				"gitops.doFluxCheck": {
+					"type": "boolean",
+					"default": true,
+					"description": "Enable Flux Check (uncheck to skip flux check)"
+				},
 				"gitops.weaveGitopsEnterprise": {
 					"type": "boolean",
 					"default": false,

--- a/src/cli/checkVersions.ts
+++ b/src/cli/checkVersions.ts
@@ -1,6 +1,6 @@
 import { commands, Uri, window } from 'vscode';
 
-import { enabledWGE, telemetry } from 'extension';
+import { enabledWGE, telemetry, enabledFluxChecks } from 'extension';
 import { Errorable, failed } from 'types/errorable';
 import { CommandId } from 'types/extensionIds';
 import { TelemetryError } from 'types/telemetryEventNames';
@@ -104,14 +104,17 @@ export async function getFluxVersion(): Promise<Errorable<string>> {
  * @see https://fluxcd.io/docs/cmd/flux_check/
  */
 export async function checkFluxPrerequisites() {
-	const prerequisiteShellResult = await shell.execWithOutput('flux check --pre', { revealOutputView: false });
-
-	if (prerequisiteShellResult.code !== 0) {
-		const showOutput = 'Show Output';
-		const showOutputConfirm = await window.showWarningMessage('Flux prerequisites check failed.', showOutput);
-		if (showOutput === showOutputConfirm) {
-			commands.executeCommand(CommandId.ShowOutputChannel);
+	if(enabledFluxChecks()) {
+		const prerequisiteShellResult = await shell.execWithOutput('flux check --pre', { revealOutputView: false });
+		if (prerequisiteShellResult.code !== 0) {
+			const showOutput = 'Show Output';
+			const showOutputConfirm = await window.showWarningMessage('Flux prerequisites check failed.', showOutput);
+			if (showOutput === showOutputConfirm) {
+				commands.executeCommand(CommandId.ShowOutputChannel);
+			}
 		}
+	} else {
+		window.showInformationMessage('DEBUG: not running `flux check`');
 	}
 }
 

--- a/src/cli/flux/fluxTools.ts
+++ b/src/cli/flux/fluxTools.ts
@@ -64,6 +64,8 @@ class FluxTools {
 	 * https://github.com/fluxcd/flux2/blob/main/cmd/flux/check.go
 	 */
 	async check(context: string): Promise<{ prerequisites: FluxPrerequisite[]; controllers: FluxController[]; } | undefined> {
+		// cannot observe extension.enabledFluxChecks here, return type is specific;
+
 		const result = await shell.execWithOutput(safesh`flux check --context ${context}`, { revealOutputView: false });
 
 		if (result.code !== 0) {

--- a/src/commands/fluxCheck.ts
+++ b/src/commands/fluxCheck.ts
@@ -2,11 +2,18 @@ import safesh from 'shell-escape-tag';
 
 import { shell } from 'cli/shell/exec';
 import { ClusterNode } from 'ui/treeviews/nodes/cluster/clusterNode';
+import { enabledFluxChecks } from 'extension';
+import { window } from 'vscode';
 
 /**
  * Runs `flux check` command for selected cluster in the output view.
  * @param clusterNode target cluster node (from tree node context menu)
  */
 export async function fluxCheck(clusterNode: ClusterNode) {
-	shell.execWithOutput(safesh`flux check --context ${clusterNode.context.name}`);
+	if(enabledFluxChecks()) {
+		shell.execWithOutput(safesh`flux check --context ${clusterNode.context.name}`);
+	} else {
+		// user called for health checking, notify them it isn't being performed
+		window.showInformationMessage('DEBUG: not running `flux check`');
+	}
 }

--- a/src/commands/fluxCheckPrerequisites.ts
+++ b/src/commands/fluxCheckPrerequisites.ts
@@ -1,8 +1,13 @@
 import { shell } from 'cli/shell/exec';
+import { enabledFluxChecks } from 'extension';
 
 /**
  * Runs `flux check --pre` command in the output view.
  */
 export async function checkFluxPrerequisites() {
-	return await shell.execWithOutput('flux check --pre');
+	if(enabledFluxChecks()) {
+		return await shell.execWithOutput('flux check --pre');
+	} else {
+		return true;
+	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -118,6 +118,15 @@ export function enabledWGE(): boolean {
 	return workspace.getConfiguration('gitops').get('weaveGitopsEnterprise') || false;
 }
 
+export function enabledFluxChecks(): boolean {
+	let ret = workspace.getConfiguration('gitops').get('doFluxCheck');
+	if(ret === false) {
+		return false;
+	} else {
+		return true;
+	}
+}
+
 
 /**
  * Called when extension is deactivated.

--- a/src/ui/treeviews/dataProviders/clusterDataProvider.ts
+++ b/src/ui/treeviews/dataProviders/clusterDataProvider.ts
@@ -1,10 +1,10 @@
 import { fluxTools } from 'cli/flux/fluxTools';
 import { getFluxControllers } from 'cli/kubernetes/kubectlGet';
 import { kubeConfig } from 'cli/kubernetes/kubernetesConfig';
-import { setVSCodeContext } from 'extension';
+import { enabledFluxChecks, setVSCodeContext } from 'extension';
 import { ContextId } from 'types/extensionIds';
 import { statusBar } from 'ui/statusBar';
-import { TreeItem } from 'vscode';
+import { TreeItem, window } from 'vscode';
 import { ClusterDeploymentNode } from '../nodes/cluster/clusterDeploymentNode';
 import { ClusterNode } from '../nodes/cluster/clusterNode';
 import { TreeNode } from '../nodes/treeNode';
@@ -114,30 +114,31 @@ export class ClusterDataProvider extends DataProvider {
 		if (!clusterNode || clusterNode.children.length === 0) {
 			return;
 		}
-		const fluxCheckResult = await fluxTools.check(clusterNode.context.name);
-		if (!fluxCheckResult) {
-			return;
-		}
+		if(enabledFluxChecks()){ // disable nixes health checking on the cluster
+			const fluxCheckResult = await fluxTools.check(clusterNode.context.name);
+			if (!fluxCheckResult) {
+				return;
+			}
+			// Match controllers fetched with flux with controllers
+			// fetched with kubectl and update tree nodes.
+			for (const clusterController of (clusterNode.children as ClusterDeploymentNode[])) {
+				for (const controller of fluxCheckResult.controllers) {
+					const clusterControllerName = clusterController.resource.metadata.name?.trim();
+					const deploymentName = controller.name.trim();
 
-		// Match controllers fetched with flux with controllers
-		// fetched with kubectl and update tree nodes.
-		for (const clusterController of (clusterNode.children as ClusterDeploymentNode[])) {
-			for (const controller of fluxCheckResult.controllers) {
-				const clusterControllerName = clusterController.resource.metadata.name?.trim();
-				const deploymentName = controller.name.trim();
-
-				if (clusterControllerName === deploymentName) {
-					clusterController.description = controller.status;
-					if (controller.success) {
-						clusterController.setStatus('success');
-					} else {
-						clusterController.setStatus('failure');
+					if (clusterControllerName === deploymentName) {
+						clusterController.description = controller.status;
+						if (controller.success) {
+							clusterController.setStatus('success');
+						} else {
+							clusterController.setStatus('failure');
+						}
 					}
 				}
+				refreshClustersTreeView(clusterController);
 			}
-			refreshClustersTreeView(clusterController);
+		} else {
+			window.showInformationMessage('DEBUG: not running `flux check`');
 		}
 	}
-
-
 }


### PR DESCRIPTION
For now, this remains a prerelease feature. We should clean up the debug information messages before it goes to release. I tested this locally and it looks like we're calling `flux check` a bit more often than we should.

I think we should fix that first, then put both this feature and that fix in the next release 0.25.1