### PR TITLE
(Prerelease) Suppress debug option

### DIFF
--- a/package.json
+++ b/package.json
@@ -283,6 +283,11 @@
 					"default": true,
 					"description": "Enable Flux Check (uncheck to skip flux check)"
 				},
+				"gitops.suppressDebugMessages": {
+					"type": "boolean",
+					"default": false,
+					"description": "Do not emit debug-level messages (only error, info, warn)"
+				},
 				"gitops.weaveGitopsEnterprise": {
 					"type": "boolean",
 					"default": false,

--- a/src/cli/checkVersions.ts
+++ b/src/cli/checkVersions.ts
@@ -1,6 +1,6 @@
 import { commands, Uri, window } from 'vscode';
 
-import { enabledWGE, telemetry, enabledFluxChecks } from 'extension';
+import { enabledWGE, telemetry, enabledFluxChecks, suppressDebugMessages } from 'extension';
 import { Errorable, failed } from 'types/errorable';
 import { CommandId } from 'types/extensionIds';
 import { TelemetryError } from 'types/telemetryEventNames';
@@ -114,7 +114,9 @@ export async function checkFluxPrerequisites() {
 			}
 		}
 	} else {
-		window.showInformationMessage('DEBUG: not running `flux check`');
+		if(!suppressDebugMessages()) {
+			window.showInformationMessage('DEBUG: not running `flux check`');
+		}
 	}
 }
 

--- a/src/commands/fluxCheck.ts
+++ b/src/commands/fluxCheck.ts
@@ -2,7 +2,7 @@ import safesh from 'shell-escape-tag';
 
 import { shell } from 'cli/shell/exec';
 import { ClusterNode } from 'ui/treeviews/nodes/cluster/clusterNode';
-import { enabledFluxChecks } from 'extension';
+import { enabledFluxChecks, suppressDebugMessages } from 'extension';
 import { window } from 'vscode';
 
 /**
@@ -14,6 +14,8 @@ export async function fluxCheck(clusterNode: ClusterNode) {
 		shell.execWithOutput(safesh`flux check --context ${clusterNode.context.name}`);
 	} else {
 		// user called for health checking, notify them it isn't being performed
-		window.showInformationMessage('DEBUG: not running `flux check`');
+		if(!suppressDebugMessages()) {
+			window.showInformationMessage('DEBUG: not running `flux check`');
+		}
 	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -127,6 +127,15 @@ export function enabledFluxChecks(): boolean {
 	}
 }
 
+export function suppressDebugMessages(): boolean {
+	let ret = workspace.getConfiguration('gitops').get('suppressDebugMessages');
+	if(ret === true) {
+		return true;
+	} else {
+		return false;
+	}
+}
+
 
 /**
  * Called when extension is deactivated.

--- a/src/ui/treeviews/dataProviders/clusterDataProvider.ts
+++ b/src/ui/treeviews/dataProviders/clusterDataProvider.ts
@@ -1,7 +1,7 @@
 import { fluxTools } from 'cli/flux/fluxTools';
 import { getFluxControllers } from 'cli/kubernetes/kubectlGet';
 import { kubeConfig } from 'cli/kubernetes/kubernetesConfig';
-import { enabledFluxChecks, setVSCodeContext } from 'extension';
+import { enabledFluxChecks, setVSCodeContext, suppressDebugMessages } from 'extension';
 import { ContextId } from 'types/extensionIds';
 import { statusBar } from 'ui/statusBar';
 import { TreeItem, window } from 'vscode';
@@ -138,7 +138,9 @@ export class ClusterDataProvider extends DataProvider {
 				refreshClustersTreeView(clusterController);
 			}
 		} else {
-			window.showInformationMessage('DEBUG: not running `flux check`');
+			if(!suppressDebugMessages()) {
+				window.showInformationMessage('DEBUG: not running `flux check`');
+			}
 		}
 	}
 }


### PR DESCRIPTION
This feature is only on the prerelease channel, but emits some debugging messages that are meant for the other authors of the extension to notice (and users won't be as interested in how many times we were apparently going to call flux check)

In the future, we may want to have debug messages that help the extension authors trace the execution of the code when something is going wrong. In regular releases, we should probably ship this setting enabled, but in the prerelease channel I want users to disable it (my stance is that since they are using the prerelease channel, they can participate in debugging and development! I don't want to put anything in the prerelease channel that would deter users from accepting that stance too.)