### PR TITLE
feat: recommend settings for log viewer

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
 		"Juozas Gaigalas <juozasgaigalas@gmail.com>",
 		"Alexander <usernamehw@gmail.com>",
 		"Taras Novak <taras.novak@randomfractals.com>",
-		"Leonardo Murillo <leonardo@weave.works>"
+		"Leonardo Murillo <leonardo@weave.works>",
+		"Seth Falco <seth@falco.fun>"
 	],
 	"publisher": "weaveworks",
 	"icon": "resources/icons/gitops-logo.png",
@@ -321,6 +322,11 @@
 					"type": "string",
 					"default": "60",
 					"description": "Seconds until SIGTERM for every shell exec (except `kubectl proxy`). Set to 0 for no timeout."
+				},
+				"gitops.ignoreConfigRecommendations": {
+					"type": "boolean",
+					"default": false,
+					"description": "Stop recommending changes to editor or extension settings."
 				}
 			}
 		},

--- a/src/commands/showLogs.ts
+++ b/src/commands/showLogs.ts
@@ -1,9 +1,9 @@
-import { commands, window } from 'vscode';
+import { ConfigurationTarget, commands, window, workspace } from 'vscode';
 
 import { getPodsOfADeployment } from 'cli/kubernetes/kubectlGet';
+import { ResourceNode, podResourceKind } from 'types/showLogsTypes';
 import { ClusterDeploymentNode } from 'ui/treeviews/nodes/cluster/clusterDeploymentNode';
 import { getResourceUri } from 'utils/getResourceUri';
-import { ResourceNode, podResourceKind } from 'types/showLogsTypes';
 
 /**
  * Show logs in the editor webview (running Kubernetes extension command)
@@ -31,4 +31,32 @@ export async function showLogs(deploymentNode: ClusterDeploymentNode): Promise<v
 	};
 
 	commands.executeCommand('extension.vsKubernetesLogs', podResourceNode);
+
+	const vscGitopsConfig = workspace.getConfiguration('gitops');
+	if (vscGitopsConfig.get('ignoreConfigRecommendations')) {
+		return;
+	}
+
+	const vscKubeConfig = workspace.getConfiguration('vscode-kubernetes.log-viewer');
+	if (vscKubeConfig.get('autorun') && vscKubeConfig.get('follow')) {
+		return;
+	}
+
+	window.showInformationMessage(
+		'It\'s recommended to autorun and follow logs by default. Do you want to apply these settings?',
+		'Apply Settings',
+		'Never Show Again',
+	).then(result => {
+		if (!result) {
+			return;
+		}
+
+		if (result === 'Never Show Again') {
+			workspace.getConfiguration('gitops').update('ignoreConfigRecommendations', true, ConfigurationTarget.Global);
+			return;
+		}
+
+		vscKubeConfig.update('autorun', true, ConfigurationTarget.Global);
+		vscKubeConfig.update('follow', true, ConfigurationTarget.Global);
+	});
 }


### PR DESCRIPTION
Introduces prompt to recommend changing the `autorun` and `follow` settings contributed by vscode-kubernetes.

This adds a setting to vscode-gitops-tools for when the user presses `Never Show Again` so that we can persist their choice.

It will show up in the following conditions:

* The user has not disabled setting recommendations.
* The settings are not already what we want them to be.

This means, even if the `ignoreConfigRecommendations` setting is false, we still won't prompt the user if they happen to already have the setting we were going to recommend.

## Demo

When the user opens the log viewer, they get prompted to change the settings, this enables autorun. Because the settings now match what the user wants, they don't get the prompt again. 👍🏽 

[](https://github.com/weaveworks/vscode-gitops-tools/assets/22801583/d19e1830-ec1d-4212-9330-cc0d587365ac)

When the user presses "Never Show Again", it changes the `ignoreConfigRecommendations` setting and the user will not be asked again. 👍🏽 

[](https://github.com/weaveworks/vscode-gitops-tools/assets/22801583/85ff57a7-8ac0-400b-b1f7-fd3b4c202d56)

## Related

* Closes https://github.com/weaveworks/vscode-gitops-tools/issues/238
